### PR TITLE
(fix): Change v1/api to api/v1

### DIFF
--- a/services/account-content-service/AccountContentService.Api/Constants/ApiRoutes.cs
+++ b/services/account-content-service/AccountContentService.Api/Constants/ApiRoutes.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Base API route prefix.
         /// </summary>
-        private const string Base = "v1/api";
+        private const string Base = "api/v1";
 
         // =====================================================
         // POSTS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized API route structure for improved standardization. All API endpoints now use the `/api/v1/...` format instead of `/v1/api/...`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->