### PR TITLE
close #83 #78

### DIFF
--- a/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
@@ -1,0 +1,234 @@
+using LiveSessionService.Api.Extensions;
+using LiveSessionService.Api.Models.Requests.Playlist;
+using LiveSessionService.Api.Models.Responses;
+using LiveSessionService.Application.Abstractions.Messaging.Dispatcher.Interfaces;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Playlists.Commands.CreateUserPlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.DeleteUserPlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.UpdateUserPlaylist;
+using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
+using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
+using LiveSessionService.Application.Features.Results.Playlists;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace LiveSessionService.Api.Controllers;
+
+/// <summary>
+/// API endpoints for User Playlist management
+/// User Playlists are personalized playlists created and managed by individual users
+/// </summary>
+[ApiController]
+[Route("api/v1/[controller]")]
+[Produces("application/json")]
+[Authorize]
+public sealed class UserPlaylistController : ControllerBase
+{
+    private readonly ICommandDispatcher _commands;
+    private readonly IQueryDispatcher _queries;
+
+    public UserPlaylistController(ICommandDispatcher commands, IQueryDispatcher queries)
+    {
+        _commands = commands;
+        _queries = queries;
+    }
+
+    /// <summary>
+    /// Get all playlists for the current user
+    /// </summary>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<List<UserPlaylistResult>>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    public async Task<IActionResult> GetMine(CancellationToken ct)
+    {
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var result = await _queries.Send<GetUserPlaylistsQuery, List<UserPlaylistResult>>(
+            new GetUserPlaylistsQuery(userId),
+            ct);
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
+    /// Get a specific playlist by ID for the current user
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<UserPlaylistResult>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 403)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
+    {
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var result = await _queries.Send<GetUserPlaylistByIdQuery, UserPlaylistResult>(
+            new GetUserPlaylistByIdQuery(id, userId),
+            ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
+    /// Create a new user playlist for the current user
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<UserPlaylistResult>), 201)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    public async Task<IActionResult> Create([FromBody] CreateUserPlaylistRequest request, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ApiResponse<object>.FailureResponse("Invalid input", (int)ErrorCode.BadRequest));
+        }
+
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var command = new CreateUserPlaylistCommand(
+            userId,
+            request.PlaylistName,
+            request.IncludeInRequests,
+            request.IncludeInOnDemand,
+            request.IsEnabled,
+            request.PlaylistOrder,
+            request.Weight);
+
+        var result = await _commands.Send<CreateUserPlaylistCommand, UserPlaylistResult>(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            return StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse());
+        }
+
+        return StatusCode(201, result.ToApiResponse());
+    }
+
+    /// <summary>
+    /// Update an existing user playlist for the current user
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="request"></param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<UserPlaylistResult>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 403)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateUserPlaylistRequest request, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ApiResponse<object>.FailureResponse("Invalid input", (int)ErrorCode.BadRequest));
+        }
+
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var command = new UpdateUserPlaylistCommand(
+            id,
+            userId,
+            request.PlaylistName,
+            request.IncludeInRequests,
+            request.IncludeInOnDemand,
+            request.IsEnabled,
+            request.PlaylistOrder,
+            request.Weight);
+
+        var result = await _commands.Send<UpdateUserPlaylistCommand, UserPlaylistResult>(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
+    /// Delete a user playlist for the current user
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="ct"></param>
+    /// <returns></returns>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 403)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var result = await _commands.Send(new DeleteUserPlaylistCommand(id, userId), ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return NoContent();
+    }
+
+    private bool TryGetCurrentUserId(out Guid userId)
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)
+            ?? User.FindFirst("sub")
+            ?? User.FindFirst("user_id");
+
+        if (userIdClaim != null && Guid.TryParse(userIdClaim.Value, out var parsedUserId))
+        {
+            userId = parsedUserId;
+            return true;
+        }
+
+        userId = Guid.Empty;
+        return false;
+    }
+}

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/CreateUserPlaylistRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/CreateUserPlaylistRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LiveSessionService.Api.Models.Requests.Playlist;
+
+public sealed class CreateUserPlaylistRequest
+{
+    [Required(ErrorMessage = "Playlist name is required")]
+    [StringLength(200, MinimumLength = 2, ErrorMessage = "Playlist name must be between 2 and 200 characters")]
+    public string PlaylistName { get; set; } = null!;
+
+    public bool IncludeInRequests { get; set; }
+    public bool IncludeInOnDemand { get; set; }
+    public bool IsEnabled { get; set; } = true;
+    public int PlaylistOrder { get; set; }
+    public int Weight { get; set; } = 1;
+}

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/UpdateUserPlaylistRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/UpdateUserPlaylistRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LiveSessionService.Api.Models.Requests.Playlist;
+
+public sealed class UpdateUserPlaylistRequest
+{
+    [StringLength(200, MinimumLength = 2, ErrorMessage = "Playlist name must be between 2 and 200 characters")]
+    public string? PlaylistName { get; set; }
+
+    public bool? IncludeInRequests { get; set; }
+    public bool? IncludeInOnDemand { get; set; }
+    public bool? IsEnabled { get; set; }
+    public int? PlaylistOrder { get; set; }
+
+    [Range(0, int.MaxValue, ErrorMessage = "Weight cannot be negative")]
+    public int? Weight { get; set; }
+}

--- a/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
@@ -25,11 +25,16 @@ using LiveSessionService.Application.Features.NowPlaying.Queries.GetNowPlaying;
 using LiveSessionService.Application.Features.NowPlaying.Queries.GetNowPlayingHistory;
 using LiveSessionService.Application.Features.Playlists.Commands.AddMediaToPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.CreatePlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.CreateUserPlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.DeleteUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.RemoveMediaFromPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.SyncPlaylists;
 using LiveSessionService.Application.Features.Playlists.Commands.UpdatePlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.UpdateUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Queries.GetPlaylistsByStation;
 using LiveSessionService.Application.Features.Playlists.Queries.GetPlaylistTracks;
+using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
+using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
 using LiveSessionService.Application.Features.Podcasts.Commands.CreatePodcast;
 using LiveSessionService.Application.Features.Podcasts.Commands.DeletePodcast;
 using LiveSessionService.Application.Features.Podcasts.Commands.UpdatePodcast;
@@ -87,7 +92,10 @@ public static class DependencyInjection
 
         // Register Playlist Command Handlers
         services.AddScoped<ICommandHandler<CreatePlaylistCommand, PlaylistResult>, CreatePlaylistHandler>();
+        services.AddScoped<ICommandHandler<CreateUserPlaylistCommand, UserPlaylistResult>, CreateUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<UpdatePlaylistCommand, PlaylistResult>, UpdatePlaylistHandler>();
+        services.AddScoped<ICommandHandler<UpdateUserPlaylistCommand, UserPlaylistResult>, UpdateUserPlaylistHandler>();
+        services.AddScoped<ICommandHandler<DeleteUserPlaylistCommand>, DeleteUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<AddMediaToPlaylistCommand, PlaylistMediaResult>, AddMediaToPlaylistHandler>();
         services.AddScoped<ICommandHandler<RemoveMediaFromPlaylistCommand>, RemoveMediaFromPlaylistHandler>();
         services.AddScoped<ICommandHandler<SyncPlaylistsCommand, SyncPlaylistsResult>, SyncPlaylistsHandler>();
@@ -111,6 +119,8 @@ public static class DependencyInjection
 
         // Register Playlist Query Handlers
         services.AddScoped<IQueryHandler<GetPlaylistsByStationQuery, List<PlaylistResult>>, GetPlaylistsByStationHandler>();
+        services.AddScoped<IQueryHandler<GetUserPlaylistsQuery, List<UserPlaylistResult>>, GetUserPlaylistsHandler>();
+        services.AddScoped<IQueryHandler<GetUserPlaylistByIdQuery, UserPlaylistResult>, GetUserPlaylistByIdHandler>();
         services.AddScoped<IQueryHandler<GetPlaylistTracksQuery, List<PlaylistMediaResult>>, GetPlaylistTracksHandler>();
 
         // Register Podcast Command Handlers

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/DeleteSessionSchedule/DeleteSessionScheduleHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/DeleteSessionSchedule/DeleteSessionScheduleHandler.cs
@@ -1,6 +1,8 @@
 using LiveSessionService.Application.Abstractions.Messaging;
 using LiveSessionService.Application.Enums;
 using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Domain.Enums;
+using LiveSessionService.Domain.Exceptions;
 using LiveSessionService.Domain.Interfaces;
 
 namespace LiveSessionService.Application.Features.LiveSessions.Commands.DeleteSessionSchedule;
@@ -8,10 +10,17 @@ namespace LiveSessionService.Application.Features.LiveSessions.Commands.DeleteSe
 public sealed class DeleteSessionScheduleHandler : ICommandHandler<DeleteSessionScheduleCommand>
 {
     private readonly ISessionScheduleRepository _scheduleRepository;
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IDateTimeProvider _dateTimeProvider;
 
-    public DeleteSessionScheduleHandler(ISessionScheduleRepository scheduleRepository)
+    public DeleteSessionScheduleHandler(
+        ISessionScheduleRepository scheduleRepository,
+        ILiveSessionRepository sessionRepository,
+        IDateTimeProvider dateTimeProvider)
     {
         _scheduleRepository = scheduleRepository;
+        _sessionRepository = sessionRepository;
+        _dateTimeProvider = dateTimeProvider;
     }
 
     public async Task<Result> Handle(DeleteSessionScheduleCommand command, CancellationToken cancellationToken)
@@ -22,7 +31,27 @@ public sealed class DeleteSessionScheduleHandler : ICommandHandler<DeleteSession
             return Result.Failure("Schedule not found", ErrorCode.NotFound);
         }
 
+        var session = await _sessionRepository.GetByIdAsync(schedule.LiveSessionId, cancellationToken);
+        if (session == null)
+        {
+            return Result.Failure("Session not found", ErrorCode.NotFound);
+        }
+
         await _scheduleRepository.DeleteAsync(schedule, cancellationToken);
+
+        if (session.Status == SessionStatus.Scheduled)
+        {
+            try
+            {
+                session.RevertToCreated(_dateTimeProvider);
+                await _sessionRepository.UpdateAsync(session, cancellationToken);
+            }
+            catch (DomainException ex)
+            {
+                return Result.Failure(ex.Message, (ErrorCode)ex.StatusCode);
+            }
+        }
+
         return Result.Success();
     }
 }

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/CreateUserPlaylist/CreateUserPlaylistCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/CreateUserPlaylist/CreateUserPlaylistCommand.cs
@@ -1,0 +1,13 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.Playlists;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.CreateUserPlaylist;
+
+public sealed record CreateUserPlaylistCommand(
+    Guid UserId,
+    string PlaylistName,
+    bool IncludeInRequests,
+    bool IncludeInOnDemand,
+    bool IsEnabled,
+    int PlaylistOrder,
+    int Weight) : ICommand<UserPlaylistResult>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/CreateUserPlaylist/CreateUserPlaylistHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/CreateUserPlaylist/CreateUserPlaylistHandler.cs
@@ -1,0 +1,69 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.Playlists;
+using LiveSessionService.Domain.Entities;
+using LiveSessionService.Domain.Enums;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.CreateUserPlaylist;
+
+public sealed class CreateUserPlaylistHandler : ICommandHandler<CreateUserPlaylistCommand, UserPlaylistResult>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public CreateUserPlaylistHandler(
+        IUserPlaylistRepository userPlaylistRepository,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<UserPlaylistResult>> Handle(CreateUserPlaylistCommand command, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(command.PlaylistName))
+        {
+            return Result<UserPlaylistResult>.Failure("Playlist name is required", ErrorCode.BadRequest);
+        }
+
+        if (command.Weight < 0)
+        {
+            return Result<UserPlaylistResult>.Failure("Weight cannot be negative", ErrorCode.BadRequest);
+        }
+
+        var playlist = new UserPlaylist
+        {
+            Id = Guid.NewGuid(),
+            UserId = command.UserId,
+            ExternalPlaylistId = 0,
+            PlaylistName = command.PlaylistName.Trim(),
+            Type = PlaylistType.Default,
+            Source = PlaylistSource.Songs,
+            PlaylistOrder = command.PlaylistOrder,
+            IsEnabled = command.IsEnabled,
+            IncludeInRequests = command.IncludeInRequests,
+            IncludeInOnDemand = command.IncludeInOnDemand,
+            Weight = command.Weight,
+            CreatedAt = _dateTimeProvider.UtcNow
+        };
+
+        await _userPlaylistRepository.AddAsync(playlist, cancellationToken);
+
+        return Result<UserPlaylistResult>.Success(new UserPlaylistResult
+        {
+            Id = playlist.Id,
+            UserId = playlist.UserId,
+            PlaylistName = playlist.PlaylistName,
+            IsEnabled = playlist.IsEnabled,
+            IncludeInRequests = playlist.IncludeInRequests,
+            IncludeInOnDemand = playlist.IncludeInOnDemand,
+            PlaylistOrder = playlist.PlaylistOrder,
+            Weight = playlist.Weight,
+            TotalTracks = 0,
+            CreatedAt = playlist.CreatedAt,
+            UpdatedAt = playlist.UpdatedAt
+        });
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeleteUserPlaylist/DeleteUserPlaylistCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeleteUserPlaylist/DeleteUserPlaylistCommand.cs
@@ -1,0 +1,5 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.DeleteUserPlaylist;
+
+public sealed record DeleteUserPlaylistCommand(Guid PlaylistId, Guid UserId) : ICommand;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeleteUserPlaylist/DeleteUserPlaylistHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeleteUserPlaylist/DeleteUserPlaylistHandler.cs
@@ -1,0 +1,33 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.DeleteUserPlaylist;
+
+public sealed class DeleteUserPlaylistHandler : ICommandHandler<DeleteUserPlaylistCommand>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+
+    public DeleteUserPlaylistHandler(IUserPlaylistRepository userPlaylistRepository)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+    }
+
+    public async Task<Result> Handle(DeleteUserPlaylistCommand command, CancellationToken cancellationToken)
+    {
+        var playlist = await _userPlaylistRepository.GetByIdAsync(command.PlaylistId, cancellationToken);
+        if (playlist == null)
+        {
+            return Result.Failure("Playlist not found", ErrorCode.NotFound);
+        }
+
+        if (playlist.UserId != command.UserId)
+        {
+            return Result.Failure("You do not have permission to delete this playlist", ErrorCode.Forbidden);
+        }
+
+        await _userPlaylistRepository.DeleteAsync(playlist, cancellationToken);
+        return Result.Success();
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/UpdateUserPlaylist/UpdateUserPlaylistCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/UpdateUserPlaylist/UpdateUserPlaylistCommand.cs
@@ -1,0 +1,14 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.Playlists;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.UpdateUserPlaylist;
+
+public sealed record UpdateUserPlaylistCommand(
+    Guid PlaylistId,
+    Guid UserId,
+    string? PlaylistName,
+    bool? IncludeInRequests,
+    bool? IncludeInOnDemand,
+    bool? IsEnabled,
+    int? PlaylistOrder,
+    int? Weight) : ICommand<UserPlaylistResult>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/UpdateUserPlaylist/UpdateUserPlaylistHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/UpdateUserPlaylist/UpdateUserPlaylistHandler.cs
@@ -1,0 +1,89 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.Playlists;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.UpdateUserPlaylist;
+
+public sealed class UpdateUserPlaylistHandler : ICommandHandler<UpdateUserPlaylistCommand, UserPlaylistResult>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public UpdateUserPlaylistHandler(
+        IUserPlaylistRepository userPlaylistRepository,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<UserPlaylistResult>> Handle(UpdateUserPlaylistCommand command, CancellationToken cancellationToken)
+    {
+        var playlist = await _userPlaylistRepository.GetByIdAsync(command.PlaylistId, cancellationToken);
+        if (playlist == null)
+        {
+            return Result<UserPlaylistResult>.Failure("Playlist not found", ErrorCode.NotFound);
+        }
+
+        if (playlist.UserId != command.UserId)
+        {
+            return Result<UserPlaylistResult>.Failure("You do not have permission to update this playlist", ErrorCode.Forbidden);
+        }
+
+        if (command.Weight.HasValue && command.Weight.Value < 0)
+        {
+            return Result<UserPlaylistResult>.Failure("Weight cannot be negative", ErrorCode.BadRequest);
+        }
+
+        if (!string.IsNullOrWhiteSpace(command.PlaylistName))
+        {
+            playlist.PlaylistName = command.PlaylistName.Trim();
+        }
+
+        if (command.IncludeInRequests.HasValue)
+        {
+            playlist.IncludeInRequests = command.IncludeInRequests.Value;
+        }
+
+        if (command.IncludeInOnDemand.HasValue)
+        {
+            playlist.IncludeInOnDemand = command.IncludeInOnDemand.Value;
+        }
+
+        if (command.IsEnabled.HasValue)
+        {
+            playlist.IsEnabled = command.IsEnabled.Value;
+        }
+
+        if (command.PlaylistOrder.HasValue)
+        {
+            playlist.PlaylistOrder = command.PlaylistOrder.Value;
+        }
+
+        if (command.Weight.HasValue)
+        {
+            playlist.Weight = command.Weight.Value;
+        }
+
+        playlist.UpdatedAt = _dateTimeProvider.UtcNow;
+
+        await _userPlaylistRepository.UpdateAsync(playlist, cancellationToken);
+
+        return Result<UserPlaylistResult>.Success(new UserPlaylistResult
+        {
+            Id = playlist.Id,
+            UserId = playlist.UserId,
+            PlaylistName = playlist.PlaylistName,
+            IsEnabled = playlist.IsEnabled,
+            IncludeInRequests = playlist.IncludeInRequests,
+            IncludeInOnDemand = playlist.IncludeInOnDemand,
+            PlaylistOrder = playlist.PlaylistOrder,
+            Weight = playlist.Weight,
+            TotalTracks = playlist.UserPlaylistMedias.Count,
+            CreatedAt = playlist.CreatedAt,
+            UpdatedAt = playlist.UpdatedAt
+        });
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdHandler.cs
@@ -1,0 +1,46 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.Playlists;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
+
+public sealed class GetUserPlaylistByIdHandler : IQueryHandler<GetUserPlaylistByIdQuery, UserPlaylistResult>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+
+    public GetUserPlaylistByIdHandler(IUserPlaylistRepository userPlaylistRepository)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+    }
+
+    public async Task<Result<UserPlaylistResult>> Handle(GetUserPlaylistByIdQuery query, CancellationToken cancellationToken)
+    {
+        var playlist = await _userPlaylistRepository.GetByIdAsync(query.PlaylistId, cancellationToken);
+        if (playlist == null)
+        {
+            return Result<UserPlaylistResult>.Failure("Playlist not found", ErrorCode.NotFound);
+        }
+
+        if (playlist.UserId != query.UserId)
+        {
+            return Result<UserPlaylistResult>.Failure("You do not have permission to access this playlist", ErrorCode.Forbidden);
+        }
+
+        return Result<UserPlaylistResult>.Success(new UserPlaylistResult
+        {
+            Id = playlist.Id,
+            UserId = playlist.UserId,
+            PlaylistName = playlist.PlaylistName,
+            IsEnabled = playlist.IsEnabled,
+            IncludeInRequests = playlist.IncludeInRequests,
+            IncludeInOnDemand = playlist.IncludeInOnDemand,
+            PlaylistOrder = playlist.PlaylistOrder,
+            Weight = playlist.Weight,
+            TotalTracks = playlist.UserPlaylistMedias.Count,
+            CreatedAt = playlist.CreatedAt,
+            UpdatedAt = playlist.UpdatedAt
+        });
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdQuery.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdQuery.cs
@@ -1,0 +1,6 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.Playlists;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
+
+public sealed record GetUserPlaylistByIdQuery(Guid PlaylistId, Guid UserId) : IQuery<UserPlaylistResult>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylists/GetUserPlaylistsHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylists/GetUserPlaylistsHandler.cs
@@ -1,0 +1,38 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.Playlists;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
+
+public sealed class GetUserPlaylistsHandler : IQueryHandler<GetUserPlaylistsQuery, List<UserPlaylistResult>>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+
+    public GetUserPlaylistsHandler(IUserPlaylistRepository userPlaylistRepository)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+    }
+
+    public async Task<Result<List<UserPlaylistResult>>> Handle(GetUserPlaylistsQuery query, CancellationToken cancellationToken)
+    {
+        var playlists = await _userPlaylistRepository.GetByUserIdAsync(query.UserId, cancellationToken);
+
+        var results = playlists.Select(x => new UserPlaylistResult
+        {
+            Id = x.Id,
+            UserId = x.UserId,
+            PlaylistName = x.PlaylistName,
+            IsEnabled = x.IsEnabled,
+            IncludeInRequests = x.IncludeInRequests,
+            IncludeInOnDemand = x.IncludeInOnDemand,
+            PlaylistOrder = x.PlaylistOrder,
+            Weight = x.Weight,
+            TotalTracks = x.UserPlaylistMedias.Count,
+            CreatedAt = x.CreatedAt,
+            UpdatedAt = x.UpdatedAt
+        }).ToList();
+
+        return Result<List<UserPlaylistResult>>.Success(results);
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylists/GetUserPlaylistsQuery.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylists/GetUserPlaylistsQuery.cs
@@ -1,0 +1,6 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.Playlists;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
+
+public sealed record GetUserPlaylistsQuery(Guid UserId) : IQuery<List<UserPlaylistResult>>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Results/Playlists/UserPlaylistResult.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Results/Playlists/UserPlaylistResult.cs
@@ -1,0 +1,16 @@
+namespace LiveSessionService.Application.Features.Results.Playlists;
+
+public sealed class UserPlaylistResult
+{
+    public Guid Id { get; init; }
+    public Guid UserId { get; init; }
+    public string PlaylistName { get; init; } = null!;
+    public bool IsEnabled { get; init; }
+    public bool IncludeInRequests { get; init; }
+    public bool IncludeInOnDemand { get; init; }
+    public int PlaylistOrder { get; init; }
+    public int Weight { get; init; }
+    public int TotalTracks { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime? UpdatedAt { get; init; }
+}

--- a/services/live-session-service/LiveSessionService.Domain/Entities/LiveSession.Methods.cs
+++ b/services/live-session-service/LiveSessionService.Domain/Entities/LiveSession.Methods.cs
@@ -120,6 +120,28 @@ public partial class LiveSession
         UpdatedAt = dateTimeProvider.UtcNow;
     }
 
+    public void RevertToCreated(IDateTimeProvider dateTimeProvider)
+    {
+        if (Status == SessionStatus.Live || Status == SessionStatus.Paused)
+            throw new InvalidSessionStateException(
+                "Cannot revert an active session to created",
+                LiveSessionErrorCodes.SessionAlreadyActive);
+
+        if (Status == SessionStatus.Ended)
+            throw new InvalidSessionStateException(
+                "Cannot revert an ended session to created",
+                LiveSessionErrorCodes.SessionAlreadyEnded);
+
+        if (Status == SessionStatus.Cancelled)
+            throw new InvalidSessionStateException(
+                "Cannot revert a cancelled session to created",
+                LiveSessionErrorCodes.SessionNotActive);
+
+        Status = SessionStatus.Created;
+        StartedAt = CreatedAt;
+        UpdatedAt = dateTimeProvider.UtcNow;
+    }
+
     /// <summary>
     /// Starts the live session.
     /// </summary>

--- a/services/live-session-service/LiveSessionService.Domain/Interfaces/IUserPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Domain/Interfaces/IUserPlaylistRepository.cs
@@ -1,0 +1,12 @@
+using LiveSessionService.Domain.Entities;
+
+namespace LiveSessionService.Domain.Interfaces;
+
+public interface IUserPlaylistRepository
+{
+    Task<UserPlaylist?> GetByIdAsync(Guid playlistId, CancellationToken cancellationToken = default);
+    Task<List<UserPlaylist>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task AddAsync(UserPlaylist playlist, CancellationToken cancellationToken = default);
+    Task UpdateAsync(UserPlaylist playlist, CancellationToken cancellationToken = default);
+    Task DeleteAsync(UserPlaylist playlist, CancellationToken cancellationToken = default);
+}

--- a/services/live-session-service/LiveSessionService.Infrastructure/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/DependencyInjection.cs
@@ -64,6 +64,7 @@ public static class DependencyInjection
         // Repositories
         services.AddScoped<ILiveSessionRepository, LiveSessionRepository>();
         services.AddScoped<ISessionScheduleRepository, SessionScheduleRepository>();
+        services.AddScoped<IUserPlaylistRepository, UserPlaylistRepository>();
         services.AddScoped<INowPlayingHistoryRepository, NowPlayingHistoryRepository>();
         services.AddScoped<IAzuraCastStationRepository, AzuraCastStationRepository>();
         services.AddScoped<IStationPlaylistRepository, StationPlaylistRepository>();

--- a/services/live-session-service/LiveSessionService.Infrastructure/Repositories/UserPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Repositories/UserPlaylistRepository.cs
@@ -1,0 +1,47 @@
+using LiveSessionService.Domain.Entities;
+using LiveSessionService.Domain.Interfaces;
+using LiveSessionService.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace LiveSessionService.Infrastructure.Repositories;
+
+public sealed class UserPlaylistRepository : IUserPlaylistRepository
+{
+    private readonly LiveSessionDbContext _db;
+
+    public UserPlaylistRepository(LiveSessionDbContext db)
+    {
+        _db = db;
+    }
+
+    public Task<UserPlaylist?> GetByIdAsync(Guid playlistId, CancellationToken cancellationToken = default)
+        => _db.UserPlaylists
+            .Include(x => x.UserPlaylistMedias)
+            .FirstOrDefaultAsync(x => x.Id == playlistId, cancellationToken);
+
+    public Task<List<UserPlaylist>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+        => _db.UserPlaylists
+            .Include(x => x.UserPlaylistMedias)
+            .Where(x => x.UserId == userId)
+            .OrderBy(x => x.PlaylistOrder)
+            .ThenByDescending(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+    public async Task AddAsync(UserPlaylist playlist, CancellationToken cancellationToken = default)
+    {
+        await _db.UserPlaylists.AddAsync(playlist, cancellationToken);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(UserPlaylist playlist, CancellationToken cancellationToken = default)
+    {
+        _db.UserPlaylists.Update(playlist);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(UserPlaylist playlist, CancellationToken cancellationToken = default)
+    {
+        _db.UserPlaylists.Remove(playlist);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
(feat): Implement CRUD User playlist, fix update status live session when delete live session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now create, view, update, and delete playlists with support for customizable names, ordering, weighting, and request/on-demand inclusion settings.
  * Deleting a scheduled session now automatically reverts the session to its created state instead of complete deletion.
  * Added permission enforcement to ensure users can only access and modify their own playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->