### PR TITLE
(feat): Implement CRUD User Playlist tracks

### DIFF
--- a/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
@@ -3,10 +3,13 @@ using LiveSessionService.Api.Models.Requests.Playlist;
 using LiveSessionService.Api.Models.Responses;
 using LiveSessionService.Application.Abstractions.Messaging.Dispatcher.Interfaces;
 using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Playlists.Commands.AddTracksToUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.CreateUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.DeleteUserPlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.RemoveTracksFromUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.UpdateUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
+using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistTracks;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
 using LiveSessionService.Application.Features.Results.Playlists;
 using Microsoft.AspNetCore.Authorization;
@@ -207,6 +210,116 @@ public sealed class UserPlaylistController : ControllerBase
         {
             return result.ErrorCode switch
             {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Get all tracks of a user playlist for the current user
+    /// </summary>
+    [HttpGet("{id:guid}/tracks")]
+    [ProducesResponseType(typeof(ApiResponse<List<PlaylistMediaResult>>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 403)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> GetTracks(Guid id, CancellationToken ct)
+    {
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var result = await _queries.Send<GetUserPlaylistTracksQuery, List<PlaylistMediaResult>>(
+            new GetUserPlaylistTracksQuery(id, userId),
+            ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
+    /// Add tracks to a user playlist for the current user
+    /// </summary>
+    [HttpPost("{id:guid}/tracks")]
+    [ProducesResponseType(typeof(ApiResponse<List<PlaylistMediaResult>>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 403)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> AddTracks(Guid id, [FromBody] AddUserPlaylistTracksRequest request, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ApiResponse<object>.FailureResponse("Invalid input", (int)ErrorCode.BadRequest));
+        }
+
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var result = await _commands.Send<AddTracksToUserPlaylistCommand, List<PlaylistMediaResult>>(
+            new AddTracksToUserPlaylistCommand(id, userId, request.MediaIds),
+            ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
+    /// Remove tracks from a user playlist for the current user
+    /// </summary>
+    [HttpDelete("{id:guid}/tracks")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 403)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> RemoveTracks(Guid id, [FromBody] RemoveUserPlaylistTracksRequest request, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ApiResponse<object>.FailureResponse("Invalid input", (int)ErrorCode.BadRequest));
+        }
+
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
+        }
+
+        var result = await _commands.Send(
+            new RemoveTracksFromUserPlaylistCommand(id, userId, request.MediaIds),
+            ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
                 ErrorCode.NotFound => NotFound(result.ToApiResponse()),
                 ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
                 _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/AddUserPlaylistTracksRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/AddUserPlaylistTracksRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LiveSessionService.Api.Models.Requests.Playlist;
+
+public sealed class AddUserPlaylistTracksRequest
+{
+    [Required]
+    [MinLength(1, ErrorMessage = "At least one media id is required")]
+    public List<Guid> MediaIds { get; set; } = new();
+}

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/RemoveUserPlaylistTracksRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Playlist/RemoveUserPlaylistTracksRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LiveSessionService.Api.Models.Requests.Playlist;
+
+public sealed class RemoveUserPlaylistTracksRequest
+{
+    [Required]
+    [MinLength(1, ErrorMessage = "At least one media id is required")]
+    public List<Guid> MediaIds { get; set; } = new();
+}

--- a/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
@@ -26,10 +26,12 @@ using LiveSessionService.Application.Features.NowPlaying.Commands.SyncNowPlaying
 using LiveSessionService.Application.Features.NowPlaying.Queries.GetNowPlaying;
 using LiveSessionService.Application.Features.NowPlaying.Queries.GetNowPlayingHistory;
 using LiveSessionService.Application.Features.Playlists.Commands.AddMediaToPlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.AddTracksToUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.CreatePlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.CreateUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.DeleteUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.RemoveMediaFromPlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.RemoveTracksFromUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.SyncPlaylists;
 using LiveSessionService.Application.Features.Playlists.Commands.UpdatePlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.UpdateUserPlaylist;
@@ -37,6 +39,7 @@ using LiveSessionService.Application.Features.Playlists.Queries.GetPlaylistsBySt
 using LiveSessionService.Application.Features.Playlists.Queries.GetPlaylistTracks;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
+using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistTracks;
 using LiveSessionService.Application.Features.Podcasts.Commands.CreatePodcast;
 using LiveSessionService.Application.Features.Podcasts.Commands.DeletePodcast;
 using LiveSessionService.Application.Features.Podcasts.Commands.UpdatePodcast;
@@ -53,7 +56,6 @@ using LiveSessionService.Application.Features.Results.Stations;
 using LiveSessionService.Application.Features.SongRequests.Commands.CreateSongRequest;
 using LiveSessionService.Application.Features.SongRequests.Commands.ReviewSongRequest;
 using LiveSessionService.Application.Features.SongRequests.Queries.GetSongRequestsBySession;
-using LiveSessionService.Application.Features.Stations.Commands.CreateStation;
 using LiveSessionService.Application.Features.Stations.Commands.CreateStation;
 using LiveSessionService.Application.Features.Stations.Commands.SyncStations;
 using LiveSessionService.Application.Features.Stations.Queries.GetAllStations;
@@ -101,6 +103,8 @@ public static class DependencyInjection
         services.AddScoped<ICommandHandler<UpdatePlaylistCommand, PlaylistResult>, UpdatePlaylistHandler>();
         services.AddScoped<ICommandHandler<UpdateUserPlaylistCommand, UserPlaylistResult>, UpdateUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<DeleteUserPlaylistCommand>, DeleteUserPlaylistHandler>();
+        services.AddScoped<ICommandHandler<AddTracksToUserPlaylistCommand, List<PlaylistMediaResult>>, AddTracksToUserPlaylistHandler>();
+        services.AddScoped<ICommandHandler<RemoveTracksFromUserPlaylistCommand>, RemoveTracksFromUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<AddMediaToPlaylistCommand, PlaylistMediaResult>, AddMediaToPlaylistHandler>();
         services.AddScoped<ICommandHandler<RemoveMediaFromPlaylistCommand>, RemoveMediaFromPlaylistHandler>();
         services.AddScoped<ICommandHandler<SyncPlaylistsCommand, SyncPlaylistsResult>, SyncPlaylistsHandler>();
@@ -129,6 +133,7 @@ public static class DependencyInjection
         services.AddScoped<IQueryHandler<GetUserPlaylistsQuery, List<UserPlaylistResult>>, GetUserPlaylistsHandler>();
         services.AddScoped<IQueryHandler<GetUserPlaylistByIdQuery, UserPlaylistResult>, GetUserPlaylistByIdHandler>();
         services.AddScoped<IQueryHandler<GetPlaylistTracksQuery, List<PlaylistMediaResult>>, GetPlaylistTracksHandler>();
+        services.AddScoped<IQueryHandler<GetUserPlaylistTracksQuery, List<PlaylistMediaResult>>, GetUserPlaylistTracksHandler>();
 
         // Register Podcast Command Handlers
         services.AddScoped<ICommandHandler<CreatePodcastCommand, PodcastResult>, CreatePodcastHandler>();

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/AddTracksToUserPlaylist/AddTracksToUserPlaylistCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/AddTracksToUserPlaylist/AddTracksToUserPlaylistCommand.cs
@@ -1,0 +1,9 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.Playlists;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.AddTracksToUserPlaylist;
+
+public sealed record AddTracksToUserPlaylistCommand(
+    Guid PlaylistId,
+    Guid UserId,
+    List<Guid> MediaIds) : ICommand<List<PlaylistMediaResult>>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/AddTracksToUserPlaylist/AddTracksToUserPlaylistHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/AddTracksToUserPlaylist/AddTracksToUserPlaylistHandler.cs
@@ -1,0 +1,94 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.Playlists;
+using LiveSessionService.Domain.Entities;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.AddTracksToUserPlaylist;
+
+public sealed class AddTracksToUserPlaylistHandler : ICommandHandler<AddTracksToUserPlaylistCommand, List<PlaylistMediaResult>>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+    private readonly IMediaFileRepository _mediaFileRepository;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public AddTracksToUserPlaylistHandler(
+        IUserPlaylistRepository userPlaylistRepository,
+        IMediaFileRepository mediaFileRepository,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+        _mediaFileRepository = mediaFileRepository;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result<List<PlaylistMediaResult>>> Handle(AddTracksToUserPlaylistCommand command, CancellationToken cancellationToken)
+    {
+        var mediaIds = command.MediaIds
+            .Where(x => x != Guid.Empty)
+            .Distinct()
+            .ToList();
+
+        if (mediaIds.Count == 0)
+        {
+            return Result<List<PlaylistMediaResult>>.Failure("At least one media id is required", ErrorCode.BadRequest);
+        }
+
+        var playlist = await _userPlaylistRepository.GetByIdAsync(command.PlaylistId, cancellationToken);
+        if (playlist == null)
+        {
+            return Result<List<PlaylistMediaResult>>.Failure("Playlist not found", ErrorCode.NotFound);
+        }
+
+        if (playlist.UserId != command.UserId)
+        {
+            return Result<List<PlaylistMediaResult>>.Failure("You do not have permission to modify this playlist", ErrorCode.Forbidden);
+        }
+
+        var existingMediaIds = playlist.UserPlaylistMedias
+            .Where(x => x.MediaFileId.HasValue)
+            .Select(x => x.MediaFileId!.Value)
+            .ToHashSet();
+
+        var idsToAdd = mediaIds
+            .Where(x => !existingMediaIds.Contains(x))
+            .ToList();
+
+        if (idsToAdd.Count == 0)
+        {
+            return Result<List<PlaylistMediaResult>>.Success(new List<PlaylistMediaResult>());
+        }
+
+        var mediaFiles = await _mediaFileRepository.GetByIdsAsync(idsToAdd, cancellationToken);
+        if (mediaFiles.Count != idsToAdd.Count)
+        {
+            return Result<List<PlaylistMediaResult>>.Failure("One or more media files were not found", ErrorCode.NotFound);
+        }
+
+        var now = _dateTimeProvider.UtcNow;
+        var tracks = mediaFiles.Select(x => new UserPlaylistMedia
+        {
+            Id = Guid.NewGuid(),
+            UserPlaylistId = playlist.Id,
+            MediaFileId = x.Id,
+            CreatedAt = now
+        }).ToList();
+
+        await _userPlaylistRepository.AddTracksAsync(tracks, cancellationToken);
+
+        var result = mediaFiles.Select(x => new PlaylistMediaResult
+        {
+            Id = tracks.First(t => t.MediaFileId == x.Id).Id,
+            PlaylistId = playlist.Id,
+            MediaFileId = x.Id,
+            Title = x.Title,
+            Artist = x.Artist,
+            Album = x.Album,
+            DurationSeconds = x.DurationSeconds,
+            AddedAt = now
+        }).ToList();
+
+        return Result<List<PlaylistMediaResult>>.Success(result);
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/RemoveTracksFromUserPlaylist/RemoveTracksFromUserPlaylistCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/RemoveTracksFromUserPlaylist/RemoveTracksFromUserPlaylistCommand.cs
@@ -1,0 +1,8 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.RemoveTracksFromUserPlaylist;
+
+public sealed record RemoveTracksFromUserPlaylistCommand(
+    Guid PlaylistId,
+    Guid UserId,
+    List<Guid> MediaIds) : ICommand;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/RemoveTracksFromUserPlaylist/RemoveTracksFromUserPlaylistHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/RemoveTracksFromUserPlaylist/RemoveTracksFromUserPlaylistHandler.cs
@@ -1,0 +1,53 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.RemoveTracksFromUserPlaylist;
+
+public sealed class RemoveTracksFromUserPlaylistHandler : ICommandHandler<RemoveTracksFromUserPlaylistCommand>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+
+    public RemoveTracksFromUserPlaylistHandler(IUserPlaylistRepository userPlaylistRepository)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+    }
+
+    public async Task<Result> Handle(RemoveTracksFromUserPlaylistCommand command, CancellationToken cancellationToken)
+    {
+        var mediaIds = command.MediaIds
+            .Where(x => x != Guid.Empty)
+            .Distinct()
+            .ToHashSet();
+
+        if (mediaIds.Count == 0)
+        {
+            return Result.Failure("At least one media id is required", ErrorCode.BadRequest);
+        }
+
+        var playlist = await _userPlaylistRepository.GetByIdAsync(command.PlaylistId, cancellationToken);
+        if (playlist == null)
+        {
+            return Result.Failure("Playlist not found", ErrorCode.NotFound);
+        }
+
+        if (playlist.UserId != command.UserId)
+        {
+            return Result.Failure("You do not have permission to modify this playlist", ErrorCode.Forbidden);
+        }
+
+        var tracksToRemove = playlist.UserPlaylistMedias
+            .Where(x => x.MediaFileId.HasValue && mediaIds.Contains(x.MediaFileId.Value))
+            .ToList();
+
+        if (tracksToRemove.Count == 0)
+        {
+            return Result.Failure("Tracks not found in this playlist", ErrorCode.NotFound);
+        }
+
+        await _userPlaylistRepository.RemoveTracksAsync(tracksToRemove, cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksHandler.cs
@@ -1,0 +1,50 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.Playlists;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistTracks;
+
+public sealed class GetUserPlaylistTracksHandler : IQueryHandler<GetUserPlaylistTracksQuery, List<PlaylistMediaResult>>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+
+    public GetUserPlaylistTracksHandler(IUserPlaylistRepository userPlaylistRepository)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+    }
+
+    public async Task<Result<List<PlaylistMediaResult>>> Handle(GetUserPlaylistTracksQuery query, CancellationToken cancellationToken)
+    {
+        var playlist = await _userPlaylistRepository.GetByIdAsync(query.PlaylistId, cancellationToken);
+        if (playlist == null)
+        {
+            return Result<List<PlaylistMediaResult>>.Failure("Playlist not found", ErrorCode.NotFound);
+        }
+
+        if (playlist.UserId != query.UserId)
+        {
+            return Result<List<PlaylistMediaResult>>.Failure("You do not have permission to access this playlist", ErrorCode.Forbidden);
+        }
+
+        var tracks = await _userPlaylistRepository.GetTracksAsync(query.PlaylistId, cancellationToken);
+
+        var result = tracks
+            .Where(x => x.MediaFile != null)
+            .Select(x => new PlaylistMediaResult
+            {
+                Id = x.Id,
+                PlaylistId = x.UserPlaylistId,
+                MediaFileId = x.MediaFileId!.Value,
+                Title = x.MediaFile!.Title,
+                Artist = x.MediaFile.Artist,
+                Album = x.MediaFile.Album,
+                DurationSeconds = x.MediaFile.DurationSeconds,
+                AddedAt = x.CreatedAt
+            })
+            .ToList();
+
+        return Result<List<PlaylistMediaResult>>.Success(result);
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksQuery.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksQuery.cs
@@ -1,0 +1,6 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.Playlists;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistTracks;
+
+public sealed record GetUserPlaylistTracksQuery(Guid PlaylistId, Guid UserId) : IQuery<List<PlaylistMediaResult>>;

--- a/services/live-session-service/LiveSessionService.Domain/Interfaces/IUserPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Domain/Interfaces/IUserPlaylistRepository.cs
@@ -9,4 +9,7 @@ public interface IUserPlaylistRepository
     Task AddAsync(UserPlaylist playlist, CancellationToken cancellationToken = default);
     Task UpdateAsync(UserPlaylist playlist, CancellationToken cancellationToken = default);
     Task DeleteAsync(UserPlaylist playlist, CancellationToken cancellationToken = default);
+    Task AddTracksAsync(IEnumerable<UserPlaylistMedia> tracks, CancellationToken cancellationToken = default);
+    Task RemoveTracksAsync(IEnumerable<UserPlaylistMedia> tracks, CancellationToken cancellationToken = default);
+    Task<List<UserPlaylistMedia>> GetTracksAsync(Guid playlistId, CancellationToken cancellationToken = default);
 }

--- a/services/live-session-service/LiveSessionService.Infrastructure/Repositories/UserPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Repositories/UserPlaylistRepository.cs
@@ -17,6 +17,7 @@ public sealed class UserPlaylistRepository : IUserPlaylistRepository
     public Task<UserPlaylist?> GetByIdAsync(Guid playlistId, CancellationToken cancellationToken = default)
         => _db.UserPlaylists
             .Include(x => x.UserPlaylistMedias)
+                .ThenInclude(x => x.MediaFile)
             .FirstOrDefaultAsync(x => x.Id == playlistId, cancellationToken);
 
     public Task<List<UserPlaylist>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
@@ -44,4 +45,23 @@ public sealed class UserPlaylistRepository : IUserPlaylistRepository
         _db.UserPlaylists.Remove(playlist);
         await _db.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task AddTracksAsync(IEnumerable<UserPlaylistMedia> tracks, CancellationToken cancellationToken = default)
+    {
+        await _db.UserPlaylistMedias.AddRangeAsync(tracks, cancellationToken);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task RemoveTracksAsync(IEnumerable<UserPlaylistMedia> tracks, CancellationToken cancellationToken = default)
+    {
+        _db.UserPlaylistMedias.RemoveRange(tracks);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<List<UserPlaylistMedia>> GetTracksAsync(Guid playlistId, CancellationToken cancellationToken = default)
+        => _db.UserPlaylistMedias
+            .Include(x => x.MediaFile)
+            .Where(x => x.UserPlaylistId == playlistId)
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
 }


### PR DESCRIPTION
close #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new authenticated API endpoints for playlist track management:
    - Retrieve all tracks from a playlist
    - Add tracks to a playlist (requires at least one media ID)
    - Remove tracks from a playlist (requires at least one media ID)
  * All endpoints include user authorization checks to ensure access to owned playlists only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->