### PR TITLE
(feat): Add the ability to delete playlists

### DIFF
--- a/services/live-session-service/LiveSessionService.Api/Controllers/PlaylistController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/PlaylistController.cs
@@ -8,6 +8,7 @@ using LiveSessionService.Application.Features.Playlists.Commands.UpdatePlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.AddMediaToPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.RemoveMediaFromPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.SyncPlaylists;
+using LiveSessionService.Application.Features.Playlists.Commands.DeletePlaylist;
 using LiveSessionService.Application.Features.Playlists.Queries.GetPlaylistsByStation;
 using LiveSessionService.Application.Features.Playlists.Queries.GetPlaylistTracks;
 using LiveSessionService.Api.Models.Responses;
@@ -200,11 +201,22 @@ public class PlaylistController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
     public async Task<IActionResult> DeletePlaylist(Guid id, CancellationToken ct)
     {
-        _logger.LogWarning("DeletePlaylist not yet implemented");
+        var result = await _commands.Send(new DeletePlaylistCommand(id), ct);
 
-        return StatusCode(501, ApiResponse<object>.FailureResponse(
-            "Delete playlist feature coming soon",
-            501));
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.Unauthorized => Unauthorized(result.ToApiResponse()),
+                ErrorCode.Forbidden => StatusCode(403, result.ToApiResponse()),
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
+                ErrorCode.UnprocessableEntity => StatusCode(422, result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return NoContent();
     }
 
     /// <summary>

--- a/services/live-session-service/LiveSessionService.Application/Abstractions/IAzuraCastClient.cs
+++ b/services/live-session-service/LiveSessionService.Application/Abstractions/IAzuraCastClient.cs
@@ -51,6 +51,12 @@ public interface IAzuraCastClient
         bool isEnabled,
         CancellationToken cancellationToken = default);
 
+    /// <summary>Deletes a playlist in AzuraCast for the given station</summary>
+    Task DeletePlaylistAsync(
+        int stationId,
+        int playlistId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Uploads an audio file to AzuraCast station media library</summary>
     Task<AzuraCastMediaData?> UploadMediaAsync(
         int stationId,

--- a/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
@@ -29,6 +29,7 @@ using LiveSessionService.Application.Features.Playlists.Commands.AddMediaToPlayl
 using LiveSessionService.Application.Features.Playlists.Commands.AddTracksToUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.CreatePlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.CreateUserPlaylist;
+using LiveSessionService.Application.Features.Playlists.Commands.DeletePlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.DeleteUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.RemoveMediaFromPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.RemoveTracksFromUserPlaylist;
@@ -104,15 +105,16 @@ public static class DependencyInjection
 
         // Register Playlist Command Handlers
         services.AddScoped<ICommandHandler<CreatePlaylistCommand, PlaylistResult>, CreatePlaylistHandler>();
-        services.AddScoped<ICommandHandler<CreateUserPlaylistCommand, UserPlaylistResult>, CreateUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<UpdatePlaylistCommand, PlaylistResult>, UpdatePlaylistHandler>();
+        services.AddScoped<ICommandHandler<DeletePlaylistCommand>, DeletePlaylistHandler>();
+        services.AddScoped<ICommandHandler<AddMediaToPlaylistCommand, PlaylistMediaResult>, AddMediaToPlaylistHandler>();
+        services.AddScoped<ICommandHandler<RemoveMediaFromPlaylistCommand>, RemoveMediaFromPlaylistHandler>();
+        services.AddScoped<ICommandHandler<SyncPlaylistsCommand, SyncPlaylistsResult>, SyncPlaylistsHandler>();
+        services.AddScoped<ICommandHandler<CreateUserPlaylistCommand, UserPlaylistResult>, CreateUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<UpdateUserPlaylistCommand, UserPlaylistResult>, UpdateUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<DeleteUserPlaylistCommand>, DeleteUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<AddTracksToUserPlaylistCommand, List<PlaylistMediaResult>>, AddTracksToUserPlaylistHandler>();
         services.AddScoped<ICommandHandler<RemoveTracksFromUserPlaylistCommand>, RemoveTracksFromUserPlaylistHandler>();
-        services.AddScoped<ICommandHandler<AddMediaToPlaylistCommand, PlaylistMediaResult>, AddMediaToPlaylistHandler>();
-        services.AddScoped<ICommandHandler<RemoveMediaFromPlaylistCommand>, RemoveMediaFromPlaylistHandler>();
-        services.AddScoped<ICommandHandler<SyncPlaylistsCommand, SyncPlaylistsResult>, SyncPlaylistsHandler>();
 
         // Register Music Command Handlers
         services.AddScoped<ICommandHandler<UploadMusicCommand, MusicResult>, UploadMusicHandler>();

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeletePlaylist/DeletePlaylistCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeletePlaylist/DeletePlaylistCommand.cs
@@ -1,0 +1,5 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.DeletePlaylist;
+
+public sealed record DeletePlaylistCommand(Guid PlaylistId) : ICommand;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeletePlaylist/DeletePlaylistHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Commands/DeletePlaylist/DeletePlaylistHandler.cs
@@ -1,0 +1,51 @@
+using LiveSessionService.Application.Abstractions;
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Domain.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace LiveSessionService.Application.Features.Playlists.Commands.DeletePlaylist;
+
+public sealed class DeletePlaylistHandler : ICommandHandler<DeletePlaylistCommand>
+{
+    private readonly IStationPlaylistRepository _playlistRepository;
+    private readonly IPlaylistMediaRepository _playlistMediaRepository;
+    private readonly IAzuraCastClient _azuraCastClient;
+    private readonly ILogger<DeletePlaylistHandler> _logger;
+
+    public DeletePlaylistHandler(
+        IStationPlaylistRepository playlistRepository,
+        IPlaylistMediaRepository playlistMediaRepository,
+        IAzuraCastClient azuraCastClient,
+        ILogger<DeletePlaylistHandler> logger)
+    {
+        _playlistRepository = playlistRepository;
+        _playlistMediaRepository = playlistMediaRepository;
+        _azuraCastClient = azuraCastClient;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(DeletePlaylistCommand command, CancellationToken cancellationToken)
+    {
+        var playlist = await _playlistRepository.GetByIdAsync(command.PlaylistId, cancellationToken);
+        if (playlist == null)
+            return Result.Failure("Playlist not found", ErrorCode.NotFound);
+
+        await _azuraCastClient.DeletePlaylistAsync(
+            playlist.AzuraCastStation.ExternalStationId,
+            playlist.ExternalPlaylistId,
+            cancellationToken);
+
+        await _playlistMediaRepository.DeleteByPlaylistIdAsync(playlist.Id, cancellationToken);
+        await _playlistRepository.DeleteAsync(playlist, cancellationToken);
+
+        _logger.LogInformation(
+            "Deleted playlist '{PlaylistName}' (Id: {PlaylistId}, ExternalId: {ExternalId})",
+            playlist.PlaylistName,
+            playlist.Id,
+            playlist.ExternalPlaylistId);
+
+        return Result.Success();
+    }
+}

--- a/services/live-session-service/LiveSessionService.Domain/Interfaces/IStationPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Domain/Interfaces/IStationPlaylistRepository.cs
@@ -8,5 +8,6 @@ public interface IStationPlaylistRepository
     Task<List<StationPlaylist>> GetByStationIdAsync(Guid stationId, CancellationToken cancellationToken = default);
     Task AddAsync(StationPlaylist playlist, CancellationToken cancellationToken = default);
     Task UpdateAsync(StationPlaylist playlist, CancellationToken cancellationToken = default);
+    Task DeleteAsync(StationPlaylist playlist, CancellationToken cancellationToken = default);
     Task AddMediaAsync(PlaylistMedia media, CancellationToken cancellationToken = default);
 }

--- a/services/live-session-service/LiveSessionService.Infrastructure/Repositories/StationPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Repositories/StationPlaylistRepository.cs
@@ -35,6 +35,12 @@ public sealed class StationPlaylistRepository : IStationPlaylistRepository
         await _db.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task DeleteAsync(StationPlaylist playlist, CancellationToken cancellationToken = default)
+    {
+        _db.StationPlaylists.Remove(playlist);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task AddMediaAsync(PlaylistMedia media, CancellationToken cancellationToken = default)
     {
         await _db.PlaylistMedias.AddAsync(media, cancellationToken);

--- a/services/live-session-service/LiveSessionService.Infrastructure/Services/AzuraCast/AzuraCastClient.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Services/AzuraCast/AzuraCastClient.cs
@@ -317,6 +317,23 @@ public sealed class AzuraCastClient : IAzuraCastClient
         return new AzuraCastPlaylistData { Id = result.Id, Name = result.Name ?? name };
     }
 
+    public async Task DeletePlaylistAsync(
+        int stationId,
+        int playlistId,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.DeleteAsync(
+            $"api/station/{stationId}/playlist/{playlistId}",
+            cancellationToken);
+
+        await EnsureAzuraCastSuccessAsync(response, $"delete playlist {playlistId} on station {stationId}", cancellationToken);
+
+        _logger.LogInformation(
+            "Deleted AzuraCast playlist {PlaylistId} on station {StationId}",
+            playlistId,
+            stationId);
+    }
+
     public async Task<AzuraCastMediaData?> UploadMediaAsync(
         int stationId,
         Stream fileStream,


### PR DESCRIPTION
close #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented playlist deletion. Users can now delete playlists from their stations. The system includes comprehensive error handling for scenarios such as missing playlists, unauthorized access, and insufficient permissions. All associated playlist data is automatically cleaned up during the deletion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->