### PR TITLE
(feats): Add notifcation through rabibtMQ

### DIFF
--- a/services/account-content-service/AccountContentService.Api/Constants/ApiRoutes.cs
+++ b/services/account-content-service/AccountContentService.Api/Constants/ApiRoutes.cs
@@ -141,6 +141,9 @@
 
             /// <summary>Retrieve Transaction follow a user.</summary>
             public const string GetUserTransactions = $"{BaseRoute}/users/{{userId:guid}}";
+
+            /// <summary>Retrieve notifications follow a user.</summary>
+            public const string GetUserNotifications = $"{BaseRoute}/users/{{userId:guid}}/notifications";
         }
 
         // =====================================================
@@ -171,6 +174,16 @@
 
             /// <summary>Retrieve current user's transaction history.</summary>
             public const string MyTransctionHistory = $"{BaseRoute}/transaction/history";
+
+            /// <summary>Retrieve current user's all notifications.</summary>
+            public const string MyNotifications = $"{BaseRoute}/notifications";
+
+            /// <summary>Retrieve current user's read notifications.</summary>
+            public const string MyReadNotifications = $"{BaseRoute}/notifications/read";
+
+            /// <summary>Retrieve current user's not read notification.</summary>
+            public const string MyNotReadNotifications = $"{BaseRoute}/notifications/not-read";
+
         }
 
         // =====================================================

--- a/services/account-content-service/AccountContentService.Api/Contracts/Responses/NotificationResponse.cs
+++ b/services/account-content-service/AccountContentService.Api/Contracts/Responses/NotificationResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace AccountContentService.Api.Contracts.Responses
+{
+    public class NotificationResponse
+    {
+        public Guid Id { get; set; }
+        public string Type { get; set; } = string.Empty;
+        public Guid ReferenceId { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public bool IsRead { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/services/account-content-service/AccountContentService.Api/Controllers/NotificationsController.cs
+++ b/services/account-content-service/AccountContentService.Api/Controllers/NotificationsController.cs
@@ -1,8 +1,11 @@
 ﻿using AccountContentService.Api.Common;
 using AccountContentService.Api.Constants;
+using AccountContentService.Api.Contracts.Responses;
 using AccountContentService.Application.Features.Notifications.Commands.MarkAllNotificationsAsRead;
 using AccountContentService.Application.Features.Notifications.Commands.MarkNotificationAsRead;
 using AccountContentService.Application.Features.Notifications.Queries.GetNotifications;
+using AccountContentService.Domain.Entities;
+using AutoMapper;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,14 +21,55 @@ namespace AccountContentService.Api.Controllers
     public class NotificationsController : ControllerBase
     {
         private readonly IMediator _mediator;
+        private readonly IMapper _mapper;
 
         /// <summary>
         /// Initializes a new instance of <see cref="NotificationsController"/>.
         /// </summary>
         /// <param name="mediator">Mediator instance for handling CQRS requests.</param>
-        public NotificationsController(IMediator mediator)
+        /// <param name="mapper"></param>
+        public NotificationsController(IMediator mediator, IMapper mapper)
         {
             _mediator = mediator;
+            _mapper = mapper;
+        }
+
+        /// <summary>
+        /// Retrieves a paginated list of notifications for the current user.
+        /// </summary>
+        /// <param name="userId">User following retrive notifications</param>
+        /// <param name="page">Page number (default is 1).</param>
+        /// <param name="pageSize">Number of items per page (default is 10).</param>
+        /// <returns>
+        /// A paginated list of notifications including read/unread status.
+        /// </returns>
+        /// <remarks>
+        /// This API is used to display notifications in the notification center.
+        /// Supports pagination for performance optimization.
+        /// </remarks>
+        /// <response code="200">Returns the list of notifications.</response>
+        /// <response code="401">Unauthorized - user is not authenticated.</response>
+        [HttpGet(ApiRoutes.Users.GetUserNotifications)]
+        public async Task<IActionResult> GetNotifications(
+            [FromRoute] Guid userId,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10)
+        {
+            var result = await _mediator.Send(new GetNotificationsQuery
+            {
+                UserId = userId,
+                Page = page,
+                PageSize = pageSize
+            });
+            var items = _mapper.Map<IEnumerable<NotificationResponse>>(result.Items);
+
+            var response = new PaginationResponse<NotificationResponse>(
+                items,
+                result.Page,
+                result.PageSize,
+                result.TotalCount);
+
+            return Ok(ApiResponse<PaginationResponse<NotificationResponse>>.Ok(response, "Get posts successfully"));
         }
 
         /// <summary>
@@ -42,7 +86,7 @@ namespace AccountContentService.Api.Controllers
         /// </remarks>
         /// <response code="200">Returns the list of notifications.</response>
         /// <response code="401">Unauthorized - user is not authenticated.</response>
-        [HttpGet(ApiRoutes.Notifications.GetAll)]
+        [HttpGet(ApiRoutes.Me.MyNotifications)]
         public async Task<IActionResult> GetNotifications(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 10)
@@ -54,14 +98,95 @@ namespace AccountContentService.Api.Controllers
                 Page = page,
                 PageSize = pageSize
             });
+            var items = _mapper.Map<IEnumerable<NotificationResponse>>(result.Items);
 
-            return Ok(result);
+            var response = new PaginationResponse<NotificationResponse>(
+                items,
+                result.Page,
+                result.PageSize,
+                result.TotalCount);
+
+            return Ok(ApiResponse<PaginationResponse<NotificationResponse>>.Ok(response, "Get posts successfully"));
+        }
+
+        /// <summary>
+        /// Retrieves a paginated list of notifications for the current user.
+        /// </summary>
+        /// <param name="page">Page number (default is 1).</param>
+        /// <param name="pageSize">Number of items per page (default is 10).</param>
+        /// <returns>
+        /// A paginated list of read notifications.
+        /// </returns>
+        /// <remarks>
+        /// This API is used to display notifications in the notification center.
+        /// Supports pagination for performance optimization.
+        /// </remarks>
+        /// <response code="200">Returns the list of notifications.</response>
+        /// <response code="401">Unauthorized - user is not authenticated.</response>
+        [HttpGet(ApiRoutes.Me.MyReadNotifications)]
+        public async Task<IActionResult> GetReadNotifications(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10)
+        {
+            var userId = UserContext.GetUserId(HttpContext);
+            var result = await _mediator.Send(new GetReadNotificationsQuery
+            {
+                UserId = userId,
+                Page = page,
+                PageSize = pageSize
+            });
+            var items = _mapper.Map<IEnumerable<NotificationResponse>>(result.Items);
+
+            var response = new PaginationResponse<NotificationResponse>(
+                items,
+                result.Page,
+                result.PageSize,
+                result.TotalCount);
+
+            return Ok(ApiResponse<PaginationResponse<NotificationResponse>>.Ok(response, "Get posts successfully"));
+        }
+
+        /// <summary>
+        /// Retrieves a paginated list of notifications for the current user.
+        /// </summary>
+        /// <param name="page">Page number (default is 1).</param>
+        /// <param name="pageSize">Number of items per page (default is 10).</param>
+        /// <returns>
+        /// A paginated list of not read notifications
+        /// </returns>
+        /// <remarks>
+        /// This API is used to display notifications in the notification center.
+        /// Supports pagination for performance optimization.
+        /// </remarks>
+        /// <response code="200">Returns the list of notifications.</response>
+        /// <response code="401">Unauthorized - user is not authenticated.</response>
+        [HttpGet(ApiRoutes.Me.MyNotReadNotifications)]
+        public async Task<IActionResult> GetNotReadNotifications(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10)
+        {
+            var userId = UserContext.GetUserId(HttpContext);
+            var result = await _mediator.Send(new GetNotReadNotificationsQuery
+            {
+                UserId = userId,
+                Page = page,
+                PageSize = pageSize
+            });
+            var items = _mapper.Map<IEnumerable<NotificationResponse>>(result.Items);
+
+            var response = new PaginationResponse<NotificationResponse>(
+                items,
+                result.Page,
+                result.PageSize,
+                result.TotalCount);
+
+            return Ok(ApiResponse<PaginationResponse<NotificationResponse>>.Ok(response, "Get posts successfully"));
         }
 
         /// <summary>
         /// Marks a specific notification as read.
         /// </summary>
-        /// <param name="id">The unique identifier of the notification.</param>
+        /// <param name="notificationId">The unique identifier of the notification.</param>
         /// <returns>
         /// True if the notification was successfully marked as read; otherwise false.
         /// </returns>
@@ -73,9 +198,9 @@ namespace AccountContentService.Api.Controllers
         /// <response code="401">Unauthorized.</response>
         /// <response code="404">Notification not found.</response>
         [HttpPut(ApiRoutes.Notifications.Read)]
-        public async Task<IActionResult> MarkAsRead([FromRoute] Guid id)
+        public async Task<IActionResult> MarkAsRead([FromRoute] Guid notificationId)
         {
-            var result = await _mediator.Send(new MarkNotificationAsReadCommand(id));
+            var result = await _mediator.Send(new MarkNotificationAsReadCommand(notificationId));
 
             return Ok(ApiResponse<bool>.Ok(result, $"Status: {result}"));
         }

--- a/services/account-content-service/AccountContentService.Api/Extensions/ConfigurationExtensions.cs
+++ b/services/account-content-service/AccountContentService.Api/Extensions/ConfigurationExtensions.cs
@@ -19,6 +19,8 @@ public static class ConfigurationExtensions
         {
             var candidates = new[]
             {
+                Path.Combine(Directory.GetCurrentDirectory(), ".env.local"),
+                Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../../..", ".env.local")),
                 Path.Combine(Directory.GetCurrentDirectory(), ".env"),
                 Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../../..", ".env")),
                 Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../../.env")),

--- a/services/account-content-service/AccountContentService.Api/Mappings/NotificationMappingProfile.cs
+++ b/services/account-content-service/AccountContentService.Api/Mappings/NotificationMappingProfile.cs
@@ -1,0 +1,14 @@
+﻿using AccountContentService.Api.Contracts.Responses;
+using AccountContentService.Application.DTOs;
+using AutoMapper;
+
+namespace AccountContentService.Api.Mappings
+{
+    public class NotificationMappingProfile : Profile
+    {
+        public NotificationMappingProfile()
+        {
+            CreateMap<NotificationDto, NotificationResponse>();
+        }
+    }
+}

--- a/services/account-content-service/AccountContentService.Application/AccountContentService.Application.csproj
+++ b/services/account-content-service/AccountContentService.Application/AccountContentService.Application.csproj
@@ -1,26 +1,28 @@
-﻿    <Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\AccountContentService.Domain\AccountContentService.Domain.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\AccountContentService.Domain\AccountContentService.Domain.csproj" />
+		<ProjectReference Include="..\..\..\shared\shared.csproj" />
 
-  <ItemGroup>
-    <Folder Include="Common\Constants\" />
-    <Folder Include="Features\Payments\Queries\" />
-  </ItemGroup>
+	</ItemGroup>
 
-  <ItemGroup>
-	  <PackageReference Include="AutoMapper" Version="12.0.1" />
-	  <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Common\Constants\" />
+		<Folder Include="Features\Payments\Queries\" />
+	</ItemGroup>
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="AutoMapper" Version="12.0.1" />
+		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+		<PackageReference Include="FluentValidation" Version="12.1.1" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+		<PackageReference Include="MediatR" Version="14.1.0" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
 </Project>

--- a/services/account-content-service/AccountContentService.Application/Features/BlogComments/Commands/CreateComment/CreateCommentHandler.cs
+++ b/services/account-content-service/AccountContentService.Application/Features/BlogComments/Commands/CreateComment/CreateCommentHandler.cs
@@ -1,3 +1,4 @@
+using AccountContentService.Application.Abstractions;
 using AccountContentService.Application.DTOs;
 using AccountContentService.Application.Exceptions;
 using AccountContentService.Application.Interfaces.Repositories;
@@ -6,6 +7,8 @@ using AccountContentService.Domain.Entities;
 using AccountContentService.Domain.Enums;
 using AutoMapper;
 using MediatR;
+using shared.Contracts.Events.Notifications;
+using System.Text.Json;
 
 namespace AccountContentService.Application.Features.BlogComments.Commands.CreateComment
 {
@@ -15,17 +18,20 @@ namespace AccountContentService.Application.Features.BlogComments.Commands.Creat
         private readonly IBlogPostRepository _postRepository;
         private readonly IMapper _mapper;
         private readonly IUserProfileCache _userProfileCache;
+        private readonly IMessageBusPublisher _eventBus;
 
         public CreateCommentHandler(
             ICommentRepository repository,
             IBlogPostRepository postRepository,
             IMapper mapper,
-            IUserProfileCache userProfileCache)
+            IUserProfileCache userProfileCache,
+            IMessageBusPublisher eventBus)
         {
             _repository = repository;
             _postRepository = postRepository;
             _mapper = mapper;
             _userProfileCache = userProfileCache;
+            _eventBus = eventBus;
         }
 
         public async Task<CommentDto> Handle(
@@ -48,6 +54,24 @@ namespace AccountContentService.Application.Features.BlogComments.Commands.Creat
             comment.UserFullName = userProfile.FullName;
 
             await _repository.AddAsync(comment);
+
+
+            var @event = new NotificationEvent
+            {
+                Title = "New Comment",
+                SendUserId = comment.UserId,
+                ReceiveUserId = post.UserId,
+                ReferenceId = post.Id,
+                Type = "post-comment",
+                Message = $"{userProfile.FullName} commented on your post: {comment.Content}"
+            };
+
+            var payload = JsonSerializer.Serialize(@event);
+
+            await _eventBus.PublishAsync(
+                    "notification.created",
+                    payload
+            );
             return _mapper.Map<CommentDto>(comment);
         }
     }

--- a/services/account-content-service/AccountContentService.Application/Features/BlogComments/Commands/ReplyComment/ReplyCommentHandler.cs
+++ b/services/account-content-service/AccountContentService.Application/Features/BlogComments/Commands/ReplyComment/ReplyCommentHandler.cs
@@ -6,6 +6,9 @@ using AccountContentService.Domain.Entities;
 using AccountContentService.Domain.Enums;
 using AutoMapper;
 using MediatR;
+using shared.Contracts.Events.Notifications;
+using System.Text.Json;
+using System.Xml.Linq;
 
 namespace AccountContentService.Application.Features.BlogComments.Commands.ReplyComment
 {
@@ -14,15 +17,18 @@ namespace AccountContentService.Application.Features.BlogComments.Commands.Reply
         private readonly ICommentRepository _repository;
         private readonly IMapper _mapper;
         private readonly IUserProfileCache _userProfileCache;
+        private readonly IMessageBusPublisher _eventBus;
 
         public ReplyCommentHandler(
             ICommentRepository repository,
             IMapper mapper,
-            IUserProfileCache userProfileCache)
+            IUserProfileCache userProfileCache,
+            IMessageBusPublisher eventBus)
         {
             _repository = repository;
             _mapper = mapper;
             _userProfileCache = userProfileCache;
+            _eventBus = eventBus;
         }
 
         public async Task<CommentDto> Handle(
@@ -42,6 +48,24 @@ namespace AccountContentService.Application.Features.BlogComments.Commands.Reply
             reply.UserFullName = userProfile.FullName;
 
             await _repository.AddAsync(reply);
+
+
+            var @event = new NotificationEvent
+            {
+                Title = "Reply Comment",
+                SendUserId = reply.UserId,
+                ReceiveUserId = parent.UserId,
+                ReferenceId = parent.Id,
+                Type = "comment-reply",
+                Message = $"{userProfile.FullName} replied on your comment: {reply.Content}"
+            };
+
+            var payload = JsonSerializer.Serialize(@event);
+
+            await _eventBus.PublishAsync(
+                    "notification.created",
+                    payload
+            );
 
             return _mapper.Map<CommentDto>(reply);
         }

--- a/services/account-content-service/AccountContentService.Application/Features/BlogPostReactions/Commands/CreateReaction/CreateReactionHandler.cs
+++ b/services/account-content-service/AccountContentService.Application/Features/BlogPostReactions/Commands/CreateReaction/CreateReactionHandler.cs
@@ -1,32 +1,49 @@
 using AccountContentService.Application.DTOs;
+using AccountContentService.Application.Exceptions;
 using AccountContentService.Application.Interfaces.Repositories;
 using AccountContentService.Application.Interfaces.Services;
 using AccountContentService.Domain.Entities;
 using AutoMapper;
 using MediatR;
+using shared.Contracts.Events.Notifications;
+using System.Text.Json;
+using System.Xml.Linq;
 
 namespace AccountContentService.Application.Features.BlogPostReactions.Commands.CreateReaction
 {
     public class CreateReactionHandler : IRequestHandler<CreateReactionCommand, ReactionDto>
     {
         private readonly IPostReactionRepository _repository;
+        private readonly IBlogPostRepository _postRepository;
         private readonly IUserProfileCache _userProfileCache;
         private readonly IMapper _mapper;
+        private readonly IMessageBusPublisher _eventBus;
 
         public CreateReactionHandler(
             IPostReactionRepository repository,
             IUserProfileCache userProfileCache,
-            IMapper mapper)
+            IMapper mapper,
+            IMessageBusPublisher eventBus,
+            IBlogPostRepository postRepository)
         {
             _repository = repository;
             _userProfileCache = userProfileCache;
             _mapper = mapper;
+            _eventBus = eventBus;
+            _postRepository = postRepository;
         }
 
         public async Task<ReactionDto> Handle(
             CreateReactionCommand request,
             CancellationToken cancellationToken)
         {
+            var post = await _postRepository.GetByIdAsync(request.PostId, cancellationToken);
+
+            if (post == null)
+            {
+                throw new NotFoundException("Post not found");
+            }
+
             var userProfile = await _userProfileCache.GetProfileAsync(request.UserId, cancellationToken);
 
             var reaction = _mapper.Map<PostReaction>(request);
@@ -35,6 +52,23 @@ namespace AccountContentService.Application.Features.BlogPostReactions.Commands.
             reaction.UserFullName = userProfile.FullName;
 
             await _repository.AddAsync(reaction);
+
+
+            var @event = new NotificationEvent
+            {
+                Title = "New Reaction",
+                ReceiveUserId = post.UserId,
+                ReferenceId = reaction.PostId,
+                Type = "post-reaction",
+                Message = $"{userProfile.FullName} reacted on your post: {reaction.ReactionType}"
+            };
+
+            var payload = JsonSerializer.Serialize(@event);
+
+            await _eventBus.PublishAsync(
+                    "notification.created",
+                    payload
+            );
 
             return _mapper.Map<ReactionDto>(reaction);
         }

--- a/services/account-content-service/AccountContentService.Application/Features/Notifications/Queries/GetNotifications/GetNotificationsHandler.cs
+++ b/services/account-content-service/AccountContentService.Application/Features/Notifications/Queries/GetNotifications/GetNotificationsHandler.cs
@@ -9,7 +9,9 @@ using System.Text;
 namespace AccountContentService.Application.Features.Notifications.Queries.GetNotifications
 {
     public class GetNotificationsHandler
-    : IRequestHandler<GetNotificationsQuery, PaginationResult<NotificationDto>>
+    : IRequestHandler<GetNotificationsQuery, PaginationResult<NotificationDto>>,
+      IRequestHandler<GetNotReadNotificationsQuery, PaginationResult<NotificationDto>>,
+      IRequestHandler<GetReadNotificationsQuery, PaginationResult<NotificationDto>>
     {
         private readonly INotificationRepository _repository;
 
@@ -23,6 +25,68 @@ namespace AccountContentService.Application.Features.Notifications.Queries.GetNo
             CancellationToken cancellationToken)
         {
             var items = await _repository.GetByUserIdAsync(
+                request.UserId,
+                request.Page,
+                request.PageSize,
+                cancellationToken);
+
+            var total = await _repository.CountByUserIdAsync(
+                request.UserId,
+                cancellationToken);
+
+            return new PaginationResult<NotificationDto>
+            {
+                Items = items.Select(x => new NotificationDto
+                {
+                    Id = x.Id,
+                    Type = x.Type,
+                    ReferenceId = x.ReferenceId,
+                    Message = x.Message,
+                    IsRead = x.IsRead,
+                    CreatedAt = x.CreatedAt
+                }),
+                TotalCount = total,
+                Page = request.Page,
+                PageSize = request.PageSize
+            };
+        }
+
+        public async Task<PaginationResult<NotificationDto>> Handle(
+            GetNotReadNotificationsQuery request,
+            CancellationToken cancellationToken)
+        {
+            var items = await _repository.GetNotReadByUserIdAsync(
+                request.UserId,
+                request.Page,
+                request.PageSize,
+                cancellationToken);
+
+            var total = await _repository.CountByUserIdAsync(
+                request.UserId,
+                cancellationToken);
+
+            return new PaginationResult<NotificationDto>
+            {
+                Items = items.Select(x => new NotificationDto
+                {
+                    Id = x.Id,
+                    Type = x.Type,
+                    ReferenceId = x.ReferenceId,
+                    Message = x.Message,
+                    IsRead = x.IsRead,
+                    CreatedAt = x.CreatedAt
+                }),
+                TotalCount = total,
+                Page = request.Page,
+                PageSize = request.PageSize
+            };
+        }
+
+        public async Task<PaginationResult<NotificationDto>> Handle(
+            GetReadNotificationsQuery request,
+            CancellationToken cancellationToken)
+        {
+            var items = await _repository.GetReadByUserIdAsync(
                 request.UserId,
                 request.Page,
                 request.PageSize,

--- a/services/account-content-service/AccountContentService.Application/Features/Notifications/Queries/GetNotifications/GetNotificationsQuery.cs
+++ b/services/account-content-service/AccountContentService.Application/Features/Notifications/Queries/GetNotifications/GetNotificationsQuery.cs
@@ -10,4 +10,18 @@ namespace AccountContentService.Application.Features.Notifications.Queries.GetNo
         public int Page { get; set; } = 1;
         public int PageSize { get; set; } = 10;
     }
+
+    public class GetNotReadNotificationsQuery : IRequest<PaginationResult<NotificationDto>>
+    {
+        public Guid UserId { get; set; }
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 10;
+    }
+
+    public class GetReadNotificationsQuery : IRequest<PaginationResult<NotificationDto>>
+    {
+        public Guid UserId { get; set; }
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 10;
+    }
 }

--- a/services/account-content-service/AccountContentService.Application/Interfaces/Repositories/INotificationRepository.cs
+++ b/services/account-content-service/AccountContentService.Application/Interfaces/Repositories/INotificationRepository.cs
@@ -11,6 +11,10 @@ namespace AccountContentService.Application.Interfaces.Repositories
 
         Task<List<Notification>> GetByUserIdAsync(Guid userId, int page, int pageSize, CancellationToken cancellationToken);
 
+        Task<List<Notification>> GetNotReadByUserIdAsync(Guid userId, int page, int pageSize, CancellationToken cancellatioToken);
+
+        Task<List<Notification>> GetReadByUserIdAsync(Guid userId, int page, int pageSize, CancellationToken cancellationToken);
+
         Task<int> CountByUserIdAsync(Guid userId, CancellationToken cancellationToken);
 
         Task MarkAsReadAsync(Guid notificationId, CancellationToken cancellationToken);

--- a/services/account-content-service/AccountContentService.Application/Interfaces/Services/IMessageBusPublisher.cs
+++ b/services/account-content-service/AccountContentService.Application/Interfaces/Services/IMessageBusPublisher.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AccountContentService.Application.Interfaces.Services
+{
+    public interface IMessageBusPublisher
+    {
+        Task PublishAsync(string type, string payload, CancellationToken ct = default);
+    }
+}

--- a/services/account-content-service/AccountContentService.Infrastructure/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -1,11 +1,12 @@
+using AccountContentService.Application.Interfaces;
 using AccountContentService.Application.Interfaces.Repositories;
 using AccountContentService.Application.Interfaces.Services;
-using AccountContentService.Application.Interfaces;
 using AccountContentService.Application.Services;
 using AccountContentService.Infrastructure.Configurations;
 using AccountContentService.Infrastructure.Integrations.Services;
 using AccountContentService.Infrastructure.Messaging;
 using AccountContentService.Infrastructure.Messaging.Consumers;
+using AccountContentService.Infrastructure.Messaging.Consumers.Notifications;
 using AccountContentService.Infrastructure.NotificationService.PaymentGateway;
 using AccountContentService.Infrastructure.Persistence;
 using AccountContentService.Infrastructure.Repositories;
@@ -39,6 +40,8 @@ public static class InfrastructureServiceCollectionExtensions
         // EDA — RabbitMQ user-event consumer
         services.AddScoped<UserEventConsumer>();
         services.AddHostedService<UserEventConsumerHostedService>();
+        services.AddScoped<NotificationEventConsumer>();
+        services.AddHostedService<NotificationEventConsumerHostedService>();
 
         // Payment configs
         services.Configure<VNPayConfig>(configuration.GetSection("VNPay"));
@@ -62,6 +65,7 @@ public static class InfrastructureServiceCollectionExtensions
         // Config event publishers (RabbitMQ)
         services.AddSingleton<IGeminiConfigEventPublisher, GeminiConfigEventPublisher>();
         services.AddSingleton<IAzuraCastConfigEventPublisher, AzuraCastConfigEventPublisher>();
+        services.AddScoped<IMessageBusPublisher, RabbitMqPublisher>();
 
         services.Configure<RabbitMqOptions>(configuration.GetSection("RabbitMq"));
 

--- a/services/account-content-service/AccountContentService.Infrastructure/Messaging/Consumers/Notifications/NotificationEventConsumer.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Messaging/Consumers/Notifications/NotificationEventConsumer.cs
@@ -1,0 +1,174 @@
+﻿using AccountContentService.Application.Interfaces.Repositories;
+using AccountContentService.Domain.Entities;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using shared.Contracts.Events.Notifications;
+using Shared.Contracts.Events.Auth;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace AccountContentService.Infrastructure.Messaging.Consumers.Notifications
+{
+    public class NotificationEventConsumer : IAsyncDisposable
+    {
+        private const string ExchangeName = "soundmates.events";
+        private const string QueueName = "account-content.notification-events";
+
+        private readonly INotificationRepository _repo;
+        private readonly RabbitMqOptions _options;
+        private readonly ILogger<NotificationEventConsumer> _logger;
+        private readonly ConnectionFactory _factory;
+
+        private IConnection? _connection;
+        private IChannel? _channel;
+        private bool _started;
+
+        public NotificationEventConsumer(
+            IOptions<RabbitMqOptions> options,
+            INotificationRepository repo,
+            ILogger<NotificationEventConsumer> logger)
+        {
+            _options = options.Value;
+            _repo = repo;
+            _logger = logger;
+            _factory = new ConnectionFactory
+            {
+                HostName = _options.HostName,
+                Port = _options.Port,
+                UserName = _options.UserName,
+                Password = _options.Password,
+                VirtualHost = _options.VirtualHost,
+                AutomaticRecoveryEnabled = true,
+                NetworkRecoveryInterval = TimeSpan.FromSeconds(10)
+            };
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (_started) return;
+
+            _connection = await _factory.CreateConnectionAsync(
+                clientProvidedName: "account-content-service-consumer",
+                cancellationToken);
+
+            _channel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
+
+            // Declare exchange
+            await _channel.ExchangeDeclareAsync(
+                exchange: ExchangeName,
+                type: ExchangeType.Topic,
+                durable: true,
+                autoDelete: false,
+                cancellationToken: cancellationToken);
+
+            // Declare queue
+            var queueArgs = new Dictionary<string, object?>();
+            await _channel.QueueDeclareAsync(
+                queue: QueueName,
+                durable: true,
+                exclusive: false,
+                autoDelete: false,
+                arguments: queueArgs,
+                cancellationToken: cancellationToken);
+
+            // Bind queue to exchange with wildcard routing key (all user events)
+            await _channel.QueueBindAsync(
+                queue: QueueName,
+                exchange: ExchangeName,
+                routingKey: "notification.#", 
+                cancellationToken: cancellationToken);
+
+            // Set prefetch count (process 10 messages at a time)
+            await _channel.BasicQosAsync(prefetchSize: 0, prefetchCount: 10, global: false, cancellationToken: cancellationToken);
+
+            var consumer = new AsyncEventingBasicConsumer(_channel);
+            consumer.ReceivedAsync += async (_, ea) =>
+            {
+                var routingKey = ea.RoutingKey;
+                var body = ea.Body.ToArray();
+                var json = Encoding.UTF8.GetString(body);
+
+                try
+                {
+                    await ProcessMessageAsync(routingKey, json, cancellationToken);
+                    await _channel.BasicAckAsync(ea.DeliveryTag, multiple: false, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to process message with routing key {RoutingKey}: {Json}", routingKey, json);
+                    // Negative ack — requeue once then move to DLQ
+                    await _channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: false, cancellationToken);
+                }
+            };
+
+            await _channel.BasicConsumeAsync(
+                queue: QueueName,
+                autoAck: false,
+                consumer: consumer,
+                cancellationToken: cancellationToken);
+
+            _started = true;
+            _logger.LogInformation(
+                "UserEventConsumer started. Listening on queue {Queue} bound to exchange {Exchange}",
+                QueueName, ExchangeName);
+        }
+
+        private async Task ProcessMessageAsync(string routingKey, string json, CancellationToken ct)
+        {
+            switch (routingKey)
+            {
+                case "notification.created":
+                    await HandleNotificationCreatedAsync(json, ct);
+                    break;
+
+                default:
+                    _logger.LogDebug("Ignoring event with routing key {RoutingKey}", routingKey);
+                    break;
+            }
+        }
+
+        private async Task HandleNotificationCreatedAsync(
+            string json,
+            CancellationToken cancellationToken)
+        {
+            var evt = JsonSerializer.Deserialize<NotificationEvent>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            if (evt == null)
+            {
+                _logger.LogWarning("Failed to deserialize UserCreatedEvent: {Json}", json);
+                return;
+            }
+            var notification = new Notification
+            {
+                Id = Guid.NewGuid(),
+                UserId = evt.ReceiveUserId,
+                Title = evt.Title,
+                ReferenceId = evt.ReferenceId,
+                Type = evt.Type,
+                Message = evt.Message,
+                IsRead = false,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _repo.AddAsync(notification, cancellationToken);
+
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_channel != null) await _channel.CloseAsync();
+            _channel?.Dispose();
+            if (_connection != null) await _connection.CloseAsync();
+            _connection?.Dispose();
+        }
+    }
+}

--- a/services/account-content-service/AccountContentService.Infrastructure/Messaging/Consumers/Notifications/NotificationEventConsumerHostedService.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Messaging/Consumers/Notifications/NotificationEventConsumerHostedService.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AccountContentService.Infrastructure.Messaging.Consumers.Notifications
+{
+    public sealed class NotificationEventConsumerHostedService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<NotificationEventConsumerHostedService> _logger;
+
+        public NotificationEventConsumerHostedService(
+            IServiceScopeFactory scopeFactory,
+            ILogger<NotificationEventConsumerHostedService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(3), stoppingToken);
+
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+
+                var consumer = scope.ServiceProvider
+                    .GetRequiredService<NotificationEventConsumer>();
+
+                await consumer.StartAsync(stoppingToken);
+
+                await Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Notification consumer shutting down");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Notification consumer failed");
+            }
+        }
+    }
+}

--- a/services/account-content-service/AccountContentService.Infrastructure/Messaging/Consumers/UserEventConsumerHostedService.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Messaging/Consumers/UserEventConsumerHostedService.cs
@@ -28,7 +28,7 @@ public sealed class UserEventConsumerHostedService : BackgroundService
 
         try
         {
-            using var scope = _scopeFactory.CreateAsyncScope();
+            await using var scope = _scopeFactory.CreateAsyncScope();
             var consumer = scope.ServiceProvider.GetRequiredService<UserEventConsumer>();
             await consumer.StartAsync(stoppingToken);
 

--- a/services/account-content-service/AccountContentService.Infrastructure/Messaging/RabbitMqPublisher.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Messaging/RabbitMqPublisher.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using AccountContentService.Application.Interfaces.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
+
+namespace AccountContentService.Infrastructure.Messaging;
+
+public sealed class RabbitMqPublisher : IMessageBusPublisher
+{
+    private readonly ConnectionFactory _factory;
+    private readonly ILogger<RabbitMqPublisher> _logger;
+    private IConnection? _connection;
+
+    public RabbitMqPublisher(IConfiguration cfg, ILogger<RabbitMqPublisher> logger)
+    {
+        _logger = logger;
+        
+        // Read from environment variables first (Docker/Kubernetes), then from config
+        var hostName = Environment.GetEnvironmentVariable("RABBITMQ_HOST") 
+                    ?? cfg["RabbitMq:HostName"]?.Replace("${RABBITMQ_HOST}", "")?.Trim()
+                    ?? cfg["RABBITMQ_HOST"] 
+                    ?? "rabbitmq";
+        
+        if (hostName.Contains("${"))
+        {
+            hostName = "rabbitmq";
+        }
+        
+        var portStr = Environment.GetEnvironmentVariable("RABBITMQ_PORT") 
+                   ?? cfg["RabbitMq:Port"]?.Replace("${RABBITMQ_PORT}", "")?.Trim()
+                   ?? cfg["RABBITMQ_PORT"] 
+                   ?? "5672";
+        
+        var userName = Environment.GetEnvironmentVariable("RABBITMQ_USERNAME") 
+                    ?? cfg["RabbitMq:UserName"]?.Replace("${RABBITMQ_USERNAME}", "")?.Trim()
+                    ?? cfg["RABBITMQ_USERNAME"] 
+                    ?? "guest";
+        
+        var password = Environment.GetEnvironmentVariable("RABBITMQ_PASSWORD") 
+                    ?? cfg["RabbitMq:Password"]?.Replace("${RABBITMQ_PASSWORD}", "")?.Trim()
+                    ?? cfg["RABBITMQ_PASSWORD"] 
+                    ?? "guest";
+        
+        var virtualHost = Environment.GetEnvironmentVariable("RABBITMQ_VIRTUALHOST") 
+                       ?? cfg["RabbitMq:VirtualHost"]?.Replace("${RABBITMQ_VIRTUALHOST}", "")?.Trim()
+                       ?? cfg["RABBITMQ_VIRTUALHOST"] 
+                       ?? "/";
+        
+        _factory = new ConnectionFactory
+        {
+            HostName = hostName,
+            Port = int.TryParse(portStr, out var p) ? p : 5672,
+            UserName = userName,
+            Password = password,
+            VirtualHost = virtualHost,
+            AutomaticRecoveryEnabled = true,
+            NetworkRecoveryInterval = TimeSpan.FromSeconds(10),
+            RequestedConnectionTimeout = TimeSpan.FromSeconds(30)
+        };
+        
+        _logger.LogInformation("RabbitMQ Publisher Configuration: Host={Host}, Port={Port}, VHost={VHost}", 
+            _factory.HostName, _factory.Port, _factory.VirtualHost);
+    }
+
+    private async Task<IConnection> GetConnectionAsync(CancellationToken ct)
+    {
+        if (_connection is { IsOpen: true })
+            return _connection;
+
+        try
+        {
+            _logger.LogInformation("Creating RabbitMQ connection to {Host}:{Port}",
+                _factory.HostName, _factory.Port);
+
+            _connection = await _factory.CreateConnectionAsync(
+                clientProvidedName: "account-content-service-publisher",
+                cancellationToken: ct);
+
+            _logger.LogInformation("RabbitMQ connection established");
+            return _connection;
+        }
+        catch (BrokerUnreachableException ex)
+        {
+            _logger.LogError(ex, "Failed to connect to RabbitMQ broker");
+            throw;
+        }
+    }
+
+    public async Task PublishAsync(string type, string payload, CancellationToken ct = default)
+    {
+        const string exchange = "soundmates.events";
+
+        try
+        {
+            var conn = await GetConnectionAsync(ct);
+            await using var channel = await conn.CreateChannelAsync(cancellationToken: ct);
+
+            await channel.ExchangeDeclareAsync(
+                exchange: exchange,
+                type: ExchangeType.Topic,
+                durable: true,
+                autoDelete: false,
+                arguments: null,
+                cancellationToken: ct);
+
+            var body = Encoding.UTF8.GetBytes(payload);
+            var props = new BasicProperties
+            {
+                ContentType = "application/json",
+                DeliveryMode = DeliveryModes.Persistent
+            };
+
+            await channel.BasicPublishAsync(
+                exchange: exchange,
+                routingKey: type,
+                mandatory: false,
+                basicProperties: props,
+                body: body,
+                cancellationToken: ct);
+
+            _logger.LogInformation("Published message to RabbitMQ: {Type}", type);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to publish message to RabbitMQ: {Type}", type);
+            throw;
+        }
+    }
+}

--- a/services/account-content-service/AccountContentService.Infrastructure/Persistence/AccountContentDbContextFactory.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Persistence/AccountContentDbContextFactory.cs
@@ -30,6 +30,8 @@ public class AccountContentDbContextFactory : IDesignTimeDbContextFactory<Accoun
         {
             var candidates = new[]
             {
+                Path.Combine(Directory.GetCurrentDirectory(), ".env.local"),
+                Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../../..", ".env.local")),
                 Path.Combine(Directory.GetCurrentDirectory(), ".env"),
                 Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../../..", ".env")),
                 Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../../.env")),

--- a/services/account-content-service/AccountContentService.Infrastructure/Repositories/NotificationRepository .cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Repositories/NotificationRepository .cs
@@ -1,5 +1,6 @@
 ﻿using AccountContentService.Application.Interfaces.Repositories;
 using AccountContentService.Domain.Entities;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
@@ -37,6 +38,34 @@ namespace AccountContentService.Infrastructure.Repositories
                 .ToListAsync(cancellationToken);
         }
 
+        public async Task<List<Notification>> GetNotReadByUserIdAsync(
+            Guid userId,
+            int page,
+            int pageSize,
+            CancellationToken cancellationToken)
+        {
+            return await _context.Notifications
+                .Where(x => x.UserId == userId && !x.IsRead)
+                .OrderByDescending(x => x.CreatedAt)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<List<Notification>> GetReadByUserIdAsync(
+            Guid userId,
+            int page,
+            int pageSize,
+            CancellationToken cancellationToken)
+        {
+            return await _context.Notifications
+                .Where(x => x.UserId == userId && x.IsRead)
+                .OrderByDescending(x => x.CreatedAt)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken);
+        }
+
         public async Task<int> CountByUserIdAsync(Guid userId, CancellationToken cancellationToken)
         {
             return await _context.Notifications
@@ -51,6 +80,8 @@ namespace AccountContentService.Infrastructure.Repositories
             if (notification == null) return;
 
             notification.IsRead = true;
+            _context.Notifications.Update(notification);
+            await _context.SaveChangesAsync(cancellationToken);
         }
 
         public async Task MarkAllAsReadAsync(Guid userId, CancellationToken cancellationToken)
@@ -62,7 +93,9 @@ namespace AccountContentService.Infrastructure.Repositories
             foreach (var noti in notifications)
             {
                 noti.IsRead = true;
+                _context.Notifications.Update(noti);
             }
+            await _context.SaveChangesAsync(cancellationToken);
         }
     }
 }

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/CreateSessionSchedule/CreateSessionScheduleHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/CreateSessionSchedule/CreateSessionScheduleHandler.cs
@@ -7,6 +7,7 @@ using LiveSessionService.Domain.Entities;
 using LiveSessionService.Domain.Enums;
 using LiveSessionService.Domain.Exceptions;
 using LiveSessionService.Domain.Interfaces;
+using shared.Contracts.Events.Notifications;
 using Shared.Contracts.Events.Notifications;
 using System.Text.Json;
 
@@ -121,18 +122,21 @@ public sealed class CreateSessionScheduleHandler : ICommandHandler<CreateSession
             session.Schedule(nextOccurrence.Value, _dateTimeProvider);
             await _sessionRepository.UpdateAsync(session, cancellationToken);
 
-            var @event = new LiveSessionScheduledEvent
+            var @event = new NotificationEvent
             {
-                SessionId = session.Id,
-                HostId = session.HostUserId,
-                StartTime = session.StartedAt ?? DateTime.UtcNow
+                Title = "Live Session Scheduled",
+                SendUserId = schedule.CreatedBy,
+                ReceiveUserId = session.HostUserId,
+                ReferenceId = session.Id,
+                Type = "live_session",
+                Message = $"Your session is scheduled at {session.StartedAt:HH:mm dd/MM/yyyy}"
             };
 
             var payload = JsonSerializer.Serialize(@event);
 
             await _eventBus.PublishAsync(
-                nameof(LiveSessionScheduledEvent),
-                payload
+                    "notification.created",
+                    payload
             );
         }
         catch (DomainException ex)

--- a/shared/Contracts/Events/Notifications/NotificationEvent.cs
+++ b/shared/Contracts/Events/Notifications/NotificationEvent.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace shared.Contracts.Events.Notifications
+{
+    public class NotificationEvent
+    {
+        public string Title { get; set; }
+        public Guid? SendUserId { get; set; }
+        public Guid ReceiveUserId { get; set; }
+        public Guid ReferenceId { get; set; }
+        public string Type { get; set; }
+        public string Message { get; set; }
+    }
+}


### PR DESCRIPTION
Feats:
- Add get read, not-read and by userId notifications endpoint api.
- Add general notification event and consumer in account-content-service (including  sendUserId, receiveUserId, Type, Title, Message, referenceId). Fix:
- Add .env.local path for local running
- Change notifaction event in create live-session schedule (not test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added notification system with endpoints to retrieve all, read, and unread notifications with pagination support.
  * Notifications are automatically generated when users comment, reply to comments, or react to blog posts.
  * Added ability to mark notifications as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->