### PR TITLE
(fix): Fix get all music catalog, create podcast, Update status podcast

### DIFF
--- a/services/live-session-service/LiveSessionService.Api/Controllers/MusicCatalogController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/MusicCatalogController.cs
@@ -290,7 +290,7 @@ public class MusicCatalogController : ControllerBase
     /// Max individual file size: 100MB
     /// Max total request size: 500MB
     /// Max files per request: 100
-    /// Files are stored in standalone system media storage (Auto-pushed to AzuraCast station)
+    /// Files are stored in standalone system media storage (not auto-pushed to AzuraCast station)
     /// </remarks>
     [HttpPost("bulk")]
     [Consumes("multipart/form-data")]

--- a/services/live-session-service/LiveSessionService.Api/Controllers/PodcastController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/PodcastController.cs
@@ -14,14 +14,21 @@ using LiveSessionService.Application.Features.Podcasts.Queries.GetPodcastEpisode
 using LiveSessionService.Application.Features.Podcasts.Queries.GetPodcastEpisodes;
 using LiveSessionService.Application.Features.Podcasts.Queries.GetPodcasts;
 using LiveSessionService.Application.Features.Results.Podcasts;
+using LiveSessionService.Domain.Enums;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using TagLib;
 
 namespace LiveSessionService.Api.Controllers;
 
+/// <summary>
+/// API endpoints for Podcast management
+/// </summary>
 [ApiController]
 [Route("api/v1/[controller]")]
 [Produces("application/json")]
+[Authorize]
 public class PodcastController : ControllerBase
 {
     private static readonly string[] AllowedAudioExtensions = [".mp3", ".flac", ".wav", ".ogg"];
@@ -36,6 +43,9 @@ public class PodcastController : ControllerBase
         _queries = queries;
     }
 
+    /// <summary>
+    /// Retrieves a list of podcasts with optional filtering by creator and status
+    /// </summary>
     [HttpGet]
     [ProducesResponseType(typeof(ApiResponse<List<PodcastResult>>), 200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 400)]
@@ -59,6 +69,9 @@ public class PodcastController : ControllerBase
         return Ok(ApiResponse<List<PodcastResult>>.SuccessResponse(result.Data!, $"Retrieved {result.Data!.Count} podcast(s)"));
     }
 
+    /// <summary>
+    /// Retrieves a specific podcast by its ID
+    /// </summary>
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(ApiResponse<PodcastResult>), 200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
@@ -79,9 +92,13 @@ public class PodcastController : ControllerBase
         return Ok(result.ToApiResponse());
     }
 
+    /// <summary>
+    /// Creates a new podcast
+    /// </summary>
     [HttpPost]
     [ProducesResponseType(typeof(ApiResponse<PodcastResult>), 201)]
     [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 401)]
     public async Task<IActionResult> Create([FromBody] CreatePodcastRequest request, CancellationToken ct)
     {
         if (!ModelState.IsValid)
@@ -91,8 +108,15 @@ public class PodcastController : ControllerBase
                 (int)ErrorCode.BadRequest));
         }
 
+        if (!TryGetCurrentUserId(out var userId))
+        {
+            return Unauthorized(ApiResponse<object>.FailureResponse(
+                "Invalid or missing user token",
+                (int)ErrorCode.Unauthorized));
+        }
+
         var command = new CreatePodcastCommand(
-            request.CreatedBy,
+            userId,
             request.Title,
             request.Description,
             request.Author,
@@ -109,6 +133,9 @@ public class PodcastController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { id = result.Data!.Id }, result.ToApiResponse());
     }
 
+    /// <summary>
+    /// Updates an existing podcast by its ID
+    /// </summary>
     [HttpPut("{id:guid}")]
     [ProducesResponseType(typeof(ApiResponse<PodcastResult>), 200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 400)]
@@ -146,6 +173,67 @@ public class PodcastController : ControllerBase
         return Ok(result.ToApiResponse());
     }
 
+    /// <summary>
+    /// Updates only the status of an existing podcast by its ID
+    /// </summary>
+    [HttpPatch("{id:guid}/status")]
+    [ProducesResponseType(typeof(ApiResponse<PodcastResult>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdatePodcastStatusRequest request, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ApiResponse<object>.FailureResponse(
+                "Invalid input",
+                (int)ErrorCode.BadRequest));
+        }
+
+        if (!TryResolvePodcastStatus(request.Status, out var resolvedStatus))
+        {
+            return BadRequest(ApiResponse<object>.FailureResponse(
+                "Invalid podcast status",
+                (int)ErrorCode.BadRequest));
+        }
+
+        var existing = await _queries.Send<GetPodcastQuery, PodcastResult>(new GetPodcastQuery(id), ct);
+        if (!existing.IsSuccess)
+        {
+            return existing.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(existing.ToApiResponse()),
+                _ => StatusCode((int)(existing.ErrorCode ?? ErrorCode.InternalServerError), existing.ToApiResponse())
+            };
+        }
+
+        var podcast = existing.Data!;
+        var command = new UpdatePodcastCommand(
+            id,
+            podcast.Title,
+            podcast.Description,
+            podcast.Author,
+            podcast.Type,
+            podcast.Banner,
+            resolvedStatus.ToString());
+
+        var result = await _commands.Send<UpdatePodcastCommand, PodcastResult>(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
+    /// Deletes a podcast by its ID
+    /// </summary>
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(204)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
@@ -164,6 +252,9 @@ public class PodcastController : ControllerBase
         return NoContent();
     }
 
+    /// <summary>
+    /// Retrieves a list of episodes for a specific podcast
+    /// </summary>
     [HttpGet("{podcastId:guid}/episodes")]
     [ProducesResponseType(typeof(ApiResponse<List<PodcastEpisodeResult>>), 200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
@@ -185,6 +276,9 @@ public class PodcastController : ControllerBase
         return Ok(result.ToApiResponse());
     }
 
+    /// <summary>
+    /// Retrieves a specific episode by its ID for a given podcast
+    /// </summary>
     [HttpGet("{podcastId:guid}/episodes/{episodeId:guid}")]
     [ProducesResponseType(typeof(ApiResponse<PodcastEpisodeResult>), 200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
@@ -206,6 +300,9 @@ public class PodcastController : ControllerBase
         return Ok(result.ToApiResponse());
     }
 
+    /// <summary>
+    /// Creates a new episode for a specific podcast
+    /// </summary>
     [HttpPost("{podcastId:guid}/episodes")]
     [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(ApiResponse<PodcastEpisodeResult>), 201)]
@@ -277,6 +374,9 @@ public class PodcastController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Updates an existing episode for a specific podcast
+    /// </summary>
     [HttpPut("{podcastId:guid}/episodes/{episodeId:guid}")]
     [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(ApiResponse<PodcastEpisodeResult>), 200)]
@@ -350,6 +450,9 @@ public class PodcastController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Deletes an episode by its ID for a given podcast
+    /// </summary>
     [HttpDelete("{podcastId:guid}/episodes/{episodeId:guid}")]
     [ProducesResponseType(204)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
@@ -433,6 +536,41 @@ public class PodcastController : ControllerBase
         {
             return 0;
         }
+    }
+
+    private static bool TryResolvePodcastStatus(string rawStatus, out PodcastStatus status)
+    {
+        var normalized = rawStatus.Trim();
+
+        if (normalized.Equals("public", StringComparison.OrdinalIgnoreCase))
+        {
+            status = PodcastStatus.Published;
+            return true;
+        }
+
+        if (normalized.Equals("private", StringComparison.OrdinalIgnoreCase))
+        {
+            status = PodcastStatus.Draft;
+            return true;
+        }
+
+        return Enum.TryParse(normalized, true, out status);
+    }
+
+    private bool TryGetCurrentUserId(out Guid userId)
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)
+            ?? User.FindFirst("sub")
+            ?? User.FindFirst("user_id");
+
+        if (userIdClaim != null && Guid.TryParse(userIdClaim.Value, out var parsedUserId))
+        {
+            userId = parsedUserId;
+            return true;
+        }
+
+        userId = Guid.Empty;
+        return false;
     }
 }
 

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/CreatePodcastRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/CreatePodcastRequest.cs
@@ -4,9 +4,6 @@ namespace LiveSessionService.Api.Models.Requests.Podcasts;
 
 public sealed class CreatePodcastRequest
 {
-    [Required(ErrorMessage = "CreatedBy is required")]
-    public Guid CreatedBy { get; set; }
-
     [Required(ErrorMessage = "Title is required")]
     [StringLength(300, MinimumLength = 1, ErrorMessage = "Title must be between 1 and 300 characters")]
     public string Title { get; set; } = null!;

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/UpdatePodcastRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/UpdatePodcastRequest.cs
@@ -4,9 +4,8 @@ namespace LiveSessionService.Api.Models.Requests.Podcasts;
 
 public sealed class UpdatePodcastRequest
 {
-    [Required(ErrorMessage = "Title is required")]
     [StringLength(300, MinimumLength = 1, ErrorMessage = "Title must be between 1 and 300 characters")]
-    public string Title { get; set; } = null!;
+    public string? Title { get; set; }
 
     [StringLength(2000, ErrorMessage = "Description cannot exceed 2000 characters")]
     public string? Description { get; set; }

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/UpdatePodcastStatusRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/UpdatePodcastStatusRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LiveSessionService.Api.Models.Requests.Podcasts;
+
+public sealed class UpdatePodcastStatusRequest
+{
+    [Required(ErrorMessage = "Status is required")]
+    [RegularExpression("(?i)^(public|private|draft|pendingreview|published|archived)$",
+        ErrorMessage = "Status must be one of: public, private, draft, pendingreview, published, archived")]
+    public string Status { get; set; } = null!;
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Music/Queries/GetAllMediaFiles/GetAllMediaFilesHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Music/Queries/GetAllMediaFiles/GetAllMediaFilesHandler.cs
@@ -10,7 +10,6 @@ namespace LiveSessionService.Application.Features.Music.Queries.GetAllMediaFiles
 public sealed class GetAllMediaFilesHandler
     : IQueryHandler<GetAllMediaFilesQuery, List<MusicResult>>
 {
-    private const string SystemMediaPrefix = "system://";
     private readonly IMediaFileRepository _mediaFiles;
     private readonly ILogger<GetAllMediaFilesHandler> _logger;
 
@@ -32,24 +31,19 @@ public sealed class GetAllMediaFilesHandler
 
             var entities = await _mediaFiles.GetAllAsync(cancellationToken);
 
-            var systemMedia = entities
-                .Where(m => !string.IsNullOrWhiteSpace(m.FilePath)
-                            && m.FilePath.StartsWith(SystemMediaPrefix, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            var results = systemMedia
+            var results = entities
                 .Select(m => new MusicResult
                 {
-                    Id         = m.Id,
+                    Id = m.Id,
                     SourceType = "system",
-                    Title      = m.Title,
-                    Artist     = m.Artist ?? string.Empty,
-                    Album      = m.Album,
+                    Title = m.Title,
+                    Artist = m.Artist ?? string.Empty,
+                    Album = m.Album,
                     ArtworkUrl = m.ArtUrl,
-                    Duration   = m.DurationSeconds,
-                    FileUrl    = m.FilePath.Substring(SystemMediaPrefix.Length),
-                    FileType   = m.FileType,
-                    FileSize   = m.FileSizeBytes,
+                    Duration = m.DurationSeconds,
+                    FileUrl = m.FilePath ?? string.Empty,
+                    FileType = m.FileType,
+                    FileSize = m.FileSizeBytes,
                     UploadedAt = m.UploadedAt
                 })
                 .ToList();

--- a/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/UpdatePodcast/UpdatePodcastCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/UpdatePodcast/UpdatePodcastCommand.cs
@@ -5,7 +5,7 @@ namespace LiveSessionService.Application.Features.Podcasts.Commands.UpdatePodcas
 
 public sealed record UpdatePodcastCommand(
     Guid PodcastId,
-    string Title,
+    string? Title,
     string? Description,
     string? Author,
     string? Type,

--- a/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/UpdatePodcast/UpdatePodcastHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/UpdatePodcast/UpdatePodcastHandler.cs
@@ -25,22 +25,55 @@ public sealed class UpdatePodcastHandler : ICommandHandler<UpdatePodcastCommand,
         if (podcast == null)
             return Result<PodcastResult>.Failure("Podcast not found", ErrorCode.NotFound);
 
+        var hasChanges = false;
+
         if (!string.IsNullOrWhiteSpace(command.Status))
         {
             if (!Enum.TryParse<PodcastStatus>(command.Status, true, out var status))
                 return Result<PodcastResult>.Failure("Invalid podcast status", ErrorCode.BadRequest);
 
-            podcast.Status = status;
+            if (podcast.Status != status)
+            {
+                podcast.Status = status;
+                hasChanges = true;
+            }
         }
 
-        podcast.Title = command.Title;
-        podcast.Description = command.Description;
-        podcast.Author = command.Author;
-        podcast.Type = command.Type;
-        podcast.Banner = command.Banner;
-        podcast.UpdatedAt = _dateTimeProvider.UtcNow;
+        if (command.Title is not null && !string.Equals(podcast.Title, command.Title, StringComparison.Ordinal))
+        {
+            podcast.Title = command.Title;
+            hasChanges = true;
+        }
 
-        await _podcastRepository.UpdateAsync(podcast, cancellationToken);
+        if (command.Description is not null && !string.Equals(podcast.Description, command.Description, StringComparison.Ordinal))
+        {
+            podcast.Description = command.Description;
+            hasChanges = true;
+        }
+
+        if (command.Author is not null && !string.Equals(podcast.Author, command.Author, StringComparison.Ordinal))
+        {
+            podcast.Author = command.Author;
+            hasChanges = true;
+        }
+
+        if (command.Type is not null && !string.Equals(podcast.Type, command.Type, StringComparison.Ordinal))
+        {
+            podcast.Type = command.Type;
+            hasChanges = true;
+        }
+
+        if (command.Banner is not null && !string.Equals(podcast.Banner, command.Banner, StringComparison.Ordinal))
+        {
+            podcast.Banner = command.Banner;
+            hasChanges = true;
+        }
+
+        if (hasChanges)
+        {
+            podcast.UpdatedAt = _dateTimeProvider.UtcNow;
+            await _podcastRepository.UpdateAsync(podcast, cancellationToken);
+        }
 
         return Result<PodcastResult>.Success(new PodcastResult
         {


### PR DESCRIPTION
close #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new endpoint to update podcast visibility status

* **Improvements**
  * Podcast endpoints now require authentication
  * Creator information automatically determined from authenticated user
  * Podcast title field is now optional when updating
  * Music service now retrieves all available media files

* **Documentation**
  * Updated music bulk upload behavior documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->