### PR TITLE
(fix): Ocelot configuration for user-saved podcast, fix podcast episode duration

### DIFF
--- a/api-gateway/ocelot.json
+++ b/api-gateway/ocelot.json
@@ -1834,6 +1834,53 @@
         "DurationOfBreak": 30000,
         "TimeoutValue": 15000
       }
+    },
+    {
+      "DownstreamPathTemplate": "/api/v1/me/saved-podcasts",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "live-session-service",
+          "Port": 8080
+        }
+      ],
+      "UpstreamPathTemplate": "/api/v1/me/saved-podcasts",
+      "UpstreamHttpMethod": [
+        "GET",
+        "OPTIONS"
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      },
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 5,
+        "DurationOfBreak": 30000,
+        "TimeoutValue": 8000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/api/v1/me/saved-podcasts/{podcastId}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "live-session-service",
+          "Port": 8080
+        }
+      ],
+      "UpstreamPathTemplate": "/api/v1/me/saved-podcasts/{podcastId}",
+      "UpstreamHttpMethod": [
+        "POST",
+        "DELETE",
+        "OPTIONS"
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      },
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 5,
+        "DurationOfBreak": 30000,
+        "TimeoutValue": 8000
+      }
     }
   ]
 }

--- a/services/live-session-service/LiveSessionService.Api/Controllers/PodcastController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/PodcastController.cs
@@ -319,7 +319,7 @@ public class PodcastController : ControllerBase
         }
 
         var resolvedAudioUrl = request.AudioUrl?.Trim();
-        int? resolvedDuration = null;
+        int? resolvedDuration = request.Duration;
 
         try
         {
@@ -393,7 +393,7 @@ public class PodcastController : ControllerBase
         }
 
         string? resolvedAudioUrl = null;
-        int? resolvedDuration = null;
+        int? resolvedDuration = request.Duration;
 
         try
         {

--- a/services/live-session-service/LiveSessionService.Api/Controllers/UserSavedPodcastController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/UserSavedPodcastController.cs
@@ -16,7 +16,7 @@ namespace LiveSessionService.Api.Controllers;
 /// API endpoints for managing User's saved podcasts
 /// </summary>
 [ApiController]
-[Route("api/v1/users/me/saved-podcasts")]
+[Route("api/v1/me/saved-podcasts")]
 [Produces("application/json")]
 [Authorize]
 public sealed class UserSavedPodcastController : ControllerBase

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/CreatePodcastEpisodeRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/CreatePodcastEpisodeRequest.cs
@@ -26,4 +26,7 @@ public sealed class CreatePodcastEpisodeRequest
     public int EpisodeNumber { get; set; }
 
     public DateTime PublishDate { get; set; }
+
+    [Range(0, int.MaxValue, ErrorMessage = "Duration cannot be negative")]
+    public int? Duration { get; set; }
 }

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/UpdatePodcastEpisodeRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/UpdatePodcastEpisodeRequest.cs
@@ -26,4 +26,7 @@ public sealed class UpdatePodcastEpisodeRequest
     public int EpisodeNumber { get; set; }
 
     public DateTime PublishDate { get; set; }
+
+    [Range(0, int.MaxValue, ErrorMessage = "Duration cannot be negative")]
+    public int? Duration { get; set; }
 }


### PR DESCRIPTION
close #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional duration field when creating or updating podcast episodes.
  * Introduced user podcast collection management, allowing users to save and manage favorite podcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->