### PR TITLE
(bug): Set default TTS timeout and add logging for configuration

### DIFF
--- a/api-gateway/ocelot.json
+++ b/api-gateway/ocelot.json
@@ -1,6 +1,7 @@
 {
   "GlobalConfiguration": {
-    "BaseUrl": "http://0.0.0.0:8080"
+    "BaseUrl": "http://0.0.0.0:8080",
+    "timeout": 600
   },
   "Routes": [
     {

--- a/services/ai-service/AiService.Api/Extensions/ConfigurationExtensions.cs
+++ b/services/ai-service/AiService.Api/Extensions/ConfigurationExtensions.cs
@@ -144,9 +144,11 @@ public static class ConfigurationExtensions
             ?? Environment.GetEnvironmentVariable("TTS_PROMPT_TEMPLATE")
             ?? configuration["Tts:PromptTemplate"];
 
-        configuration["Tts:TimeoutSeconds"] = Environment.GetEnvironmentVariable("Tts__TimeoutSeconds")
-            ?? Environment.GetEnvironmentVariable("TTS_TIMEOUT_SECONDS")
-            ?? configuration["Tts:TimeoutSeconds"];
+        configuration["Tts:TimeoutSeconds"] = FirstPositiveIntString(
+            Environment.GetEnvironmentVariable("Tts__TimeoutSeconds"),
+            Environment.GetEnvironmentVariable("TTS_TIMEOUT_SECONDS"),
+            configuration["Tts:TimeoutSeconds"])
+            ?? "100";
 
         configuration["Tts:DemoMode"] = Environment.GetEnvironmentVariable("Tts__DemoMode")
             ?? Environment.GetEnvironmentVariable("TTS_DEMO_MODE")
@@ -159,6 +161,24 @@ public static class ConfigurationExtensions
         configuration["Storage:PublicBaseUrl"] = Environment.GetEnvironmentVariable("Storage__PublicBaseUrl")
             ?? Environment.GetEnvironmentVariable("PUBLIC_BASE_URL")
             ?? configuration["Storage:PublicBaseUrl"];
+    }
+
+    private static string? FirstPositiveIntString(params string?[] candidates)
+    {
+        foreach (var raw in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                continue;
+
+            var trimmed = raw.Trim();
+            if (trimmed.StartsWith("${", StringComparison.Ordinal) && trimmed.EndsWith("}", StringComparison.Ordinal))
+                continue;
+
+            if (int.TryParse(trimmed, out var value) && value > 0)
+                return value.ToString();
+        }
+
+        return null;
     }
 }
 

--- a/services/ai-service/AiService.Infrastructure/DependencyInjection.cs
+++ b/services/ai-service/AiService.Infrastructure/DependencyInjection.cs
@@ -10,6 +10,7 @@ using AiService.Application.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Extensions.Http;
@@ -55,6 +56,7 @@ public static class DependencyInjection
         services.AddHttpClient<VieNeuTtsClient>((sp, http) =>
         {
             var options = sp.GetRequiredService<IOptions<TtsOptions>>().Value;
+            var logger = sp.GetRequiredService<ILogger<VieNeuTtsClient>>();
 
             if (!string.IsNullOrWhiteSpace(options.BaseUrl)
                 && !options.BaseUrl.StartsWith("${")
@@ -63,10 +65,14 @@ public static class DependencyInjection
                 http.BaseAddress = baseUri;
             }
 
-            if (options.TimeoutSeconds > 0)
-            {
-                http.Timeout = TimeSpan.FromSeconds(options.TimeoutSeconds);
-            }
+            var timeoutSeconds = options.TimeoutSeconds > 0 ? options.TimeoutSeconds : 100;
+            http.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+
+            logger.LogInformation(
+                "Configured VieNeu HttpClient with BaseUrl={BaseUrl}, SynthesizePath={SynthesizePath}, TimeoutSeconds={TimeoutSeconds}",
+                options.BaseUrl,
+                options.SynthesizePath,
+                timeoutSeconds);
         })
         .AddPolicyHandler(CreateCircuitBreakerPolicy());
         services.AddScoped<ITtsClient, VieNeuTtsClient>();


### PR DESCRIPTION
Add conservative defaults and logging for TTS and gateway configuration. ocelot.json: add GlobalConfiguration.timeout = 600. ConfigurationExtensions: introduce FirstPositiveIntString to pick the first valid positive integer from env/config (ignores placeholder values) and use it to set Tts:TimeoutSeconds, falling back to "100". DependencyInjection: obtain ILogger<VieNeuTtsClient>, ensure HttpClient.Timeout is always set (default 100s when options.TimeoutSeconds <= 0), and log the configured BaseUrl, SynthesizePath and TimeoutSeconds for diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured API gateway with timeout setting (600 seconds) to improve request handling
  * Enhanced Text-to-Speech service timeout configuration with improved validation logic and fallback handling
  * Added diagnostic logging to improve visibility into API client configuration and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->