### PR TITLE
(fix): Fix Create Podcast

### DIFF
--- a/services/live-session-service/LiveSessionService.Api/Controllers/PodcastController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/PodcastController.cs
@@ -117,11 +117,19 @@ public class PodcastController : ControllerBase
                 (int)ErrorCode.Unauthorized));
         }
 
+        if (!TryResolvePodcastStatus(request.Status, out var resolvedStatus))
+        {
+            return BadRequest(ApiResponse<object>.FailureResponse(
+                "Invalid podcast status",
+                (int)ErrorCode.BadRequest));
+        }
+
         var command = new CreatePodcastCommand(
             userId,
             request.Title,
             request.Description,
             request.Author,
+            resolvedStatus,
             request.Type,
             request.Banner);
 

--- a/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/CreatePodcastRequest.cs
+++ b/services/live-session-service/LiveSessionService.Api/Models/Requests/Podcasts/CreatePodcastRequest.cs
@@ -14,6 +14,11 @@ public sealed class CreatePodcastRequest
     [StringLength(200, ErrorMessage = "Author cannot exceed 200 characters")]
     public string? Author { get; set; }
 
+    [Required(ErrorMessage = "Status is required")]
+    [RegularExpression("(?i)^(public|private|draft|pendingreview|published|archived)$",
+        ErrorMessage = "Status must be one of: public, private, draft, pendingreview, published, archived")]
+    public string Status { get; set; } = null!;
+
     [StringLength(100, ErrorMessage = "Type cannot exceed 100 characters")]
     public string? Type { get; set; }
 

--- a/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/CreatePodcast/CreatePodcastCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/CreatePodcast/CreatePodcastCommand.cs
@@ -1,5 +1,6 @@
 using LiveSessionService.Application.Abstractions.Messaging;
 using LiveSessionService.Application.Features.Results.Podcasts;
+using LiveSessionService.Domain.Enums;
 
 namespace LiveSessionService.Application.Features.Podcasts.Commands.CreatePodcast;
 
@@ -8,5 +9,6 @@ public sealed record CreatePodcastCommand(
     string Title,
     string? Description,
     string? Author,
+    PodcastStatus Status,
     string? Type,
     string? Banner) : ICommand<PodcastResult>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/CreatePodcast/CreatePodcastHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Podcasts/Commands/CreatePodcast/CreatePodcastHandler.cs
@@ -30,7 +30,7 @@ public sealed class CreatePodcastHandler : ICommandHandler<CreatePodcastCommand,
             Author = command.Author,
             Type = command.Type,
             Banner = command.Banner,
-            Status = PodcastStatus.Draft,
+            Status = command.Status,
             CreatedAt = _dateTimeProvider.UtcNow
         };
 


### PR DESCRIPTION
close #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Podcast creation now requires users to specify a status with options including: public, private, draft, pendingreview, published, and archived.
  * Submitted status values are validated; invalid statuses trigger an error response.
  * Podcasts now adopt the user-specified status during creation instead of defaulting to draft.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->