### PR TITLE
(fix): Emit email-verified event; improve responses

### DIFF
--- a/services/auth-service/AuthService.Api/Controllers/UserController.cs
+++ b/services/auth-service/AuthService.Api/Controllers/UserController.cs
@@ -174,9 +174,18 @@ public class UserController : ControllerBase
         var result = await _commands.Send<VerifyUserEmailCommand, bool>(cmd, ct);
 
         if (!result.IsSuccess)
+        {
+            if (result.ErrorCode == 409)
+                return Conflict(ApiResponse<bool>.FailureResponse(
+                    result.ErrorMessage ?? "Email is already verified",
+                    result.ErrorCode ?? 409));
+            if (result.ErrorCode == 404)
+                return NotFound(ApiResponse<bool>.FailureResponse(
+                    result.ErrorMessage ?? "User not found", 404));
             return BadRequest(ApiResponse<bool>.FailureResponse(
                 result.ErrorMessage ?? "Failed to verify email",
                 result.ErrorCode ?? 400));
+        }
 
         return Ok(ApiResponse<bool>.SuccessResponse(true,
             result.ErrorMessage ?? "Email verified and account activated"));

--- a/services/auth-service/AuthService.Application/Features/Auth/Handlers/VerifyEmailHandler.cs
+++ b/services/auth-service/AuthService.Application/Features/Auth/Handlers/VerifyEmailHandler.cs
@@ -83,7 +83,7 @@ public sealed class VerifyEmailHandler : ICommandHandler<VerifyEmailCommand, Aut
             };
             await _refreshTokenRepository.AddAsync(refreshTokenEntity);
 
-            // Enqueue user updated event BEFORE commit — outbox lives in same transaction
+            // Enqueue UserUpdatedEvent — outbox lives in same transaction
             await _outbox.EnqueueAsync(RoutingKeys.Auth.UserUpdated, new UserUpdatedEvent
             {
                 Id = user.Id,
@@ -95,6 +95,16 @@ public sealed class VerifyEmailHandler : ICommandHandler<VerifyEmailCommand, Aut
                 RoleName = user.Role?.Name ?? "MEMBER",
                 IsActive = true,
                 UpdatedAt = _dateTimeProvider.UtcNow
+            }, cancellationToken);
+
+            // Enqueue UserEmailVerifiedEvent so auth-query-service syncs isVerified=true in MongoDB
+            await _outbox.EnqueueAsync(RoutingKeys.Auth.UserEmailVerified, new UserEmailVerifiedEvent
+            {
+                UserId = user.Id,
+                Username = user.Username,
+                Email = user.Email,
+                EmailVerifiedAt = user.EmailVerifiedAt ?? _dateTimeProvider.UtcNow,
+                IsActive = true
             }, cancellationToken);
 
             await _unitOfWork.CommitAsync(cancellationToken);


### PR DESCRIPTION
Enqueue a UserEmailVerifiedEvent in VerifyEmailHandler (outbox enqueued before commit) so the auth-query-service can sync isVerified=true in MongoDB; also clarified the preceding comment. Update UserController to return more specific HTTP responses: 409 Conflict for already-verified emails and 404 NotFound for missing users, using ApiResponse<bool> payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced email verification endpoint with granular error responses: returns 409 Conflict for already-verified emails and 404 Not Found for missing users.

* **New Features**
  * Added email verification event notifications to alert downstream systems of user verification status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->