### PR TITLE
(feat): Add live session queue & controls; public profiles

### DIFF
--- a/api-gateway/ocelot.json
+++ b/api-gateway/ocelot.json
@@ -150,6 +150,98 @@
       }
     },
     {
+      "DownstreamPathTemplate": "/api/v1/users/{userId}/posts",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "account-content-service",
+          "Port": 8080
+        }
+      ],
+      "UpstreamPathTemplate": "/api/v1/users/{userId}/posts",
+      "UpstreamHttpMethod": [
+        "GET",
+        "OPTIONS"
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      },
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 5,
+        "DurationOfBreak": 30000,
+        "TimeoutValue": 8000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/api/v1/users/{userId}/saved-podcasts",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "live-session-service",
+          "Port": 8080
+        }
+      ],
+      "UpstreamPathTemplate": "/api/v1/users/{userId}/saved-podcasts",
+      "UpstreamHttpMethod": [
+        "GET",
+        "OPTIONS"
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      },
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 5,
+        "DurationOfBreak": 30000,
+        "TimeoutValue": 8000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/api/v1/userplaylist/user/{userId}",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "live-session-service",
+          "Port": 8080
+        }
+      ],
+      "UpstreamPathTemplate": "/api/v1/userplaylist/user/{userId}",
+      "UpstreamHttpMethod": [
+        "GET",
+        "OPTIONS"
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      },
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 5,
+        "DurationOfBreak": 30000,
+        "TimeoutValue": 8000
+      }
+    },
+    {
+      "DownstreamPathTemplate": "/api/v1/users/{userId}/favorites",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "auth-query-service",
+          "Port": 8080
+        }
+      ],
+      "UpstreamPathTemplate": "/api/v1/users/{userId}/favorites",
+      "UpstreamHttpMethod": [
+        "GET",
+        "OPTIONS"
+      ],
+      "LoadBalancerOptions": {
+        "Type": "RoundRobin"
+      },
+      "QoSOptions": {
+        "ExceptionsAllowedBeforeBreaking": 5,
+        "DurationOfBreak": 30000,
+        "TimeoutValue": 8000
+      }
+    },
+    {
       "DownstreamPathTemplate": "/api/v1/users/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [

--- a/services/account-content-service/AccountContentService.Api/Controllers/BlogController.cs
+++ b/services/account-content-service/AccountContentService.Api/Controllers/BlogController.cs
@@ -285,7 +285,7 @@ public class BlogController : ControllerBase
     /// <param name="request"></param>
     /// <response code="200">Post retrieved successfully</response>
     /// <response code="404">Post not found</response>
-    [Authorize]
+    [AllowAnonymous]
     [HttpGet(ApiRoutes.Users.GetUserPosts)]
     public async Task<IActionResult> GetPostByUserId([FromRoute] Guid userId, [FromQuery]PaginationRequest request)
     {

--- a/services/account-content-service/AccountContentService.Application/Features/BlogPosts/Queries/GetPosts/GetPostsHandler.cs
+++ b/services/account-content-service/AccountContentService.Application/Features/BlogPosts/Queries/GetPosts/GetPostsHandler.cs
@@ -106,7 +106,7 @@ public class GetPostsHandler:
        GetUserPostDetailQuery request,
        CancellationToken cancellationToken)
     {
-        var result = await _repository.GetByUserIdAsync(request.UserId, request.PageSize, request.Page, cancellationToken);
+        var result = await _repository.GetPublishedByUserIdAsync(request.UserId, request.PageSize, request.Page, cancellationToken);
         var items = _mapper.Map<IEnumerable<PostDto>>(result.Items);
         await PopulateUserProfilesAsync(items.ToList(), cancellationToken);
 

--- a/services/account-content-service/AccountContentService.Application/Interfaces/Repositories/IBlogPostRepository.cs
+++ b/services/account-content-service/AccountContentService.Application/Interfaces/Repositories/IBlogPostRepository.cs
@@ -29,6 +29,7 @@ namespace AccountContentService.Application.Interfaces.Repositories
         Task<BlogPost> GetByIdAsync(Guid id, CancellationToken cancellationToken);
         Task<PostStatsResponse> GetPostStatsAsync(Guid postId);
         Task<PaginationResult<BlogPost>> GetByUserIdAsync(Guid userId, int pageSize, int page, CancellationToken cancellationToken);
+        Task<PaginationResult<BlogPost>> GetPublishedByUserIdAsync(Guid userId, int pageSize, int page, CancellationToken cancellationToken);
         Task<BlogPost> GetPublishByIdAsync(Guid id, CancellationToken cancellationToken);
         Task<PaginationResult<TrendingPostResponse>> GetTrendingPostsAsync(GetTrendingPostsQuery request, CancellationToken cancellationToken);
         Task<PaginationResult<PopularPostsResponse>> GetPopularPostsAsync(GetPopularPostsQuery request, CancellationToken cancellationToken);

--- a/services/account-content-service/AccountContentService.Infrastructure/Persistence/DataSeeder.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Persistence/DataSeeder.cs
@@ -195,6 +195,52 @@ public static class DataSeeder
             });
         }
 
+        if (!await context.Themes.AnyAsync(t => t.Name == "Sunset Balcony Theme"))
+        {
+            context.Themes.Add(new Theme
+            {
+                Id = Guid.NewGuid(),
+                Name = "Sunset Balcony Theme",
+                Mode = "dark",
+                IsActive = true,
+                PrimaryColor = "#FF8A65",
+                SecondaryColor = "#FFB74D",
+                BackgroundColor = "#2A233C",
+                TextColor = "#FFE0B2",
+                Mood = "sunset",
+                FontFamily = "'Poppins', 'Nunito', sans-serif",
+                GradientBackground = "linear-gradient(135deg, #2A233C 0%, #4A3B52 60%, #FF8A65 100%)",
+                PlayerColor = "#FF5252",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                ConfigJson = System.Text.Json.JsonDocument.Parse("""
+                {
+                    "borderRadius": "12px",
+                    "boxShadow": "0 8px 32px rgba(255, 138, 101, 0.25)",
+                    "backgroundImage": "https://i.postimg.cc/ZR0F56kY/bcf4f37fcab5a44ddf8c2b4cb6279e84.jpg"
+                }
+                """).RootElement
+            });
+        }
+        else
+        {
+            var existing = await context.Themes.FirstAsync(t => t.Name == "Sunset Balcony Theme");
+            existing.PrimaryColor = "#FF8A65";
+            existing.SecondaryColor = "#FFB74D";
+            existing.BackgroundColor = "#2A233C";
+            existing.TextColor = "#FFE0B2";
+            existing.GradientBackground = "linear-gradient(135deg, #2A233C 0%, #4A3B52 60%, #FF8A65 100%)";
+            existing.PlayerColor = "#FF5252";
+            existing.ConfigJson = System.Text.Json.JsonDocument.Parse("""
+                {
+                    "borderRadius": "12px",
+                    "boxShadow": "0 8px 32px rgba(255, 138, 101, 0.25)",
+                    "backgroundImage": "https://i.postimg.cc/ZR0F56kY/bcf4f37fcab5a44ddf8c2b4cb6279e84.jpg"
+                }
+                """).RootElement;
+        }
+
+
         await context.SaveChangesAsync();
 
         // ── ALWAYS patch existing plan limits in case they were created before the VoiceClone migration ──

--- a/services/account-content-service/AccountContentService.Infrastructure/Repositories/BlogPostRepository.cs
+++ b/services/account-content-service/AccountContentService.Infrastructure/Repositories/BlogPostRepository.cs
@@ -103,6 +103,41 @@ namespace AccountContentService.Infrastructure.Repositories
         }
 
         // =========================
+        // GET PUBLISHED POSTS BY USER
+        // =========================
+        public async Task<PaginationResult<BlogPost>> GetPublishedByUserIdAsync(
+            Guid userId,
+            int pageSize,
+            int page,
+            CancellationToken cancellationToken)
+        {
+            var query = _context.BlogPosts
+                .Include(x => x.Comments)
+                .Include(x => x.Reactions)
+                .AsNoTracking()
+                .Where(x => x.UserId == userId &&
+                           (x.Status.ToLower() == PostStatus.Published.ToString().ToLower()
+                            || x.Status.ToLower() == PostStatus.Edited.ToString().ToLower())
+                            && x.PrivacyScope.ToLower() == "public");
+
+            var totalCount = await query.CountAsync(cancellationToken);
+
+            var posts = await query
+                .OrderByDescending(x => x.CreatedAt)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken);
+
+            return new PaginationResult<BlogPost>
+            {
+                Items = posts,
+                TotalCount = totalCount,
+                Page = page,
+                PageSize = pageSize
+            };
+        }
+
+        // =========================
         // QUERY BUILDER
         // =========================
         private IQueryable<BlogPost> BuildQuery(

--- a/services/auth-query-service/AuthQueryService.Api/Controllers/UserController.cs
+++ b/services/auth-query-service/AuthQueryService.Api/Controllers/UserController.cs
@@ -182,6 +182,45 @@ namespace AuthQueryService.Api.Controllers
         }
 
         /// <summary>
+        /// Get user's public profile by ID (Accessible to anyone)
+        /// </summary>
+        /// <param name="id">User ID</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>User's public profile information</returns>
+        [AllowAnonymous]
+        [HttpGet("{id:guid}/public-profile")]
+        [ProducesResponseType(typeof(ApiResponse<UserFullProfileDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse<UserFullProfileDto>), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetPublicProfile(Guid id, CancellationToken ct)
+        {
+            _logger.LogInformation("Retrieving public profile for user {UserId}", id);
+            
+            var res = await _queries.Query(new GetFullUserProfileQuery(id), ct);
+            
+            if (!res.Success)
+            {
+                _logger.LogWarning("Public profile not found for user {UserId}", id);
+                return NotFound(res);
+            }
+
+            // Strip sensitive fields for non-owners/non-admins
+            var currentUserId = ResolveUserId();
+            var isAdmin = User.IsInRole("ADMIN");
+
+            if ((currentUserId == null || currentUserId != id) && !isAdmin)
+            {
+                var publicDto = res.Data! with
+                {
+                    Email = string.Empty, // Hide email
+                    Phone = null  // Hide phone
+                };
+                return Ok(ApiResponse<UserFullProfileDto>.SuccessResponse(publicDto));
+            }
+
+            return Ok(res);
+        }
+
+        /// <summary>
         /// Search users with pagination (Admin only)
         /// </summary>
         /// <param name="q">Search query (username, email, display name)</param>
@@ -278,6 +317,17 @@ namespace AuthQueryService.Api.Controllers
 
             var res = await _queries.Query(new GetUsersByRoleQuery("HOST", page, pageSize), ct);
             return Ok(res);
+        }
+
+        private Guid? ResolveUserId()
+        {
+            var userIdStr = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value 
+                          ?? User.FindFirst("sub")?.Value;
+            
+            if (Guid.TryParse(userIdStr, out var userId))
+                return userId;
+            
+            return null;
         }
     }
 }

--- a/services/auth-query-service/AuthQueryService.Application/Features/Users/UserFullProfileDto.cs
+++ b/services/auth-query-service/AuthQueryService.Application/Features/Users/UserFullProfileDto.cs
@@ -1,6 +1,6 @@
 namespace AuthQueryService.Application.DTOs
 {
-    public sealed class UserFullProfileDto
+    public sealed record UserFullProfileDto
     {
         // Account Information
         public Guid Id { get; init; }

--- a/services/live-session-service/LiveSessionService.Api/Controllers/LiveSessionController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/LiveSessionController.cs
@@ -21,6 +21,9 @@ using LiveSessionService.Application.Features.Results.SongRequests;
 using LiveSessionService.Application.Features.SongRequests.Commands.CreateSongRequest;
 using LiveSessionService.Application.Features.SongRequests.Commands.ReviewSongRequest;
 using LiveSessionService.Application.Features.SongRequests.Queries.GetSongRequestsBySession;
+using LiveSessionService.Application.Features.LiveSessions.Commands.RestartBroadcast;
+using LiveSessionService.Application.Features.LiveSessions.Commands.SkipTrack;
+using LiveSessionService.Application.Features.LiveSessions.Queries.GetLiveSessionQueue;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
@@ -170,6 +173,80 @@ public class LiveSessionController : ControllerBase
         }
 
         return Ok(ApiResponse<StationNowPlayingResult>.SuccessResponse(result.Data!, "Success"));
+    }
+
+    /// <summary>
+    /// Get upcoming song queue for a live session
+    /// </summary>
+    [HttpGet("{id:guid}/queue")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<LiveSessionQueueResult>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> GetQueue(Guid id, CancellationToken ct)
+    {
+        var query = new GetLiveSessionQueueQuery(id);
+        var result = await _queries.Send<GetLiveSessionQueueQuery, LiveSessionQueueResult>(query, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(ApiResponse<LiveSessionQueueResult>.SuccessResponse(result.Data!, "Queue retrieved"));
+    }
+
+    /// <summary>
+    /// Skip the currently playing track in a live session
+    /// </summary>
+    [HttpPost("{id:guid}/skip")]
+    [ProducesResponseType(typeof(ApiResponse<bool>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> Skip(Guid id, CancellationToken ct)
+    {
+        var command = new SkipSessionTrackCommand(id);
+        var result = await _commands.Send<SkipSessionTrackCommand, bool>(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(ApiResponse<bool>.SuccessResponse(true, "Track skipped"));
+    }
+
+    /// <summary>
+    /// Restart the broadcast/station for a live session
+    /// </summary>
+    [HttpPost("{id:guid}/restart")]
+    [ProducesResponseType(typeof(ApiResponse<bool>), 200)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+    [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+    public async Task<IActionResult> Restart(Guid id, CancellationToken ct)
+    {
+        var command = new RestartSessionBroadcastCommand(id);
+        var result = await _commands.Send<RestartSessionBroadcastCommand, bool>(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(ApiResponse<bool>.SuccessResponse(true, "Station restart requested"));
     }
 
     /// <summary>

--- a/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
@@ -60,6 +60,21 @@ public sealed class UserPlaylistController : ControllerBase
     }
 
     /// <summary>
+    /// Get all playlists for a specific user
+    /// </summary>
+    [HttpGet("user/{userId:guid}")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<List<UserPlaylistResult>>), 200)]
+    public async Task<IActionResult> GetByUserId(Guid userId, CancellationToken ct)
+    {
+        var result = await _queries.Send<GetUserPlaylistsQuery, List<UserPlaylistResult>>(
+            new GetUserPlaylistsQuery(userId),
+            ct);
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
     /// Get all public user playlists
     /// </summary>
     /// <param name="ct"></param>

--- a/services/live-session-service/LiveSessionService.Api/Controllers/UserSavedPodcastController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/UserSavedPodcastController.cs
@@ -55,6 +55,21 @@ public sealed class UserSavedPodcastController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves the list of podcasts followed by a specific user
+    /// </summary>
+    [HttpGet("/api/v1/users/{userId:guid}/saved-podcasts")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<List<PodcastResult>>), 200)]
+    public async Task<IActionResult> GetByUser(Guid userId, CancellationToken ct)
+    {
+        var result = await _queries.Send<GetFollowedPodcastsQuery, List<PodcastResult>>(
+            new GetFollowedPodcastsQuery(userId),
+            ct);
+
+        return Ok(result.ToApiResponse());
+    }
+
+    /// <summary>
     /// Follows a podcast for the current user
     /// </summary>
     [HttpPost("{podcastId:guid}")]

--- a/services/live-session-service/LiveSessionService.Application/Abstractions/IAzuraCastClient.cs
+++ b/services/live-session-service/LiveSessionService.Application/Abstractions/IAzuraCastClient.cs
@@ -110,6 +110,15 @@ public interface IAzuraCastClient
         string fileUniqueId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>Skips the currently playing track on the station</summary>
+    Task SkipTrackAsync(int stationId, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets the list of upcoming tracks in the station's queue</summary>
+    Task<List<AzuraCastCurrentSongData>> GetUpcomingQueueAsync(int stationId, CancellationToken cancellationToken = default);
+
+    /// <summary>Restarts the AzuraCast station</summary>
+    Task RestartStationAsync(int stationId, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Updates the AzuraCast configuration at runtime.
     /// Called by AzuraCastConfigEventConsumer when admin changes the config.

--- a/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
@@ -17,6 +17,9 @@ using LiveSessionService.Application.Features.LiveSessions.Queries.GetLiveSessio
 using LiveSessionService.Application.Features.LiveSessions.Queries.GetSessionSchedules;
 using LiveSessionService.Application.Features.LiveSessions.Queries.GetScheduleById;
 using LiveSessionService.Application.Features.LiveSessions.Queries.GetStaffDashboardOverview;
+using LiveSessionService.Application.Features.LiveSessions.Queries.GetLiveSessionQueue;
+using LiveSessionService.Application.Features.LiveSessions.Commands.RestartBroadcast;
+using LiveSessionService.Application.Features.LiveSessions.Commands.SkipTrack;
 using LiveSessionService.Application.Features.LiveSessions.Queries.SearchSchedules;
 using LiveSessionService.Application.Features.Music.Commands.BulkUploadMusic;
 using LiveSessionService.Application.Features.Music.Commands.DeleteMedia;
@@ -61,12 +64,6 @@ using LiveSessionService.Application.Features.Podcasts.Commands.UpdatePodcast;
 using LiveSessionService.Application.Features.Podcasts.Commands.UpdatePodcastEpisode;
 using LiveSessionService.Application.Features.Podcasts.Commands.FollowPodcast;
 using LiveSessionService.Application.Features.Podcasts.Commands.UnfollowPodcast;
-using LiveSessionService.Application.Features.PodcastRequests.Commands.CreatePodcastRequest;
-using LiveSessionService.Application.Features.PodcastRequests.Commands.ReviewPodcastRequest;
-using LiveSessionService.Application.Features.PodcastRequests.Commands.CancelPodcastRequest;
-using LiveSessionService.Application.Features.PodcastRequests.Queries.GetPodcastRequests;
-using LiveSessionService.Application.Features.PodcastRequests.Queries.GetMyPodcastRequests;
-using LiveSessionService.Application.Features.PodcastRequests.Queries.GetPodcastRequestById;
 using LiveSessionService.Application.Features.Podcasts.Queries.GetPodcast;
 using LiveSessionService.Application.Features.Podcasts.Queries.GetPodcastEpisodeById;
 using LiveSessionService.Application.Features.Podcasts.Queries.GetPodcastEpisodes;
@@ -116,6 +113,8 @@ public static class DependencyInjection
         services.AddScoped<ICommandHandler<PauseSessionCommand, LiveSessionResult>, PauseSessionHandler>();
         services.AddScoped<ICommandHandler<ResumeSessionCommand, LiveSessionResult>, ResumeSessionHandler>();
         services.AddScoped<ICommandHandler<StopSessionCommand, LiveSessionResult>, StopSessionHandler>();
+        services.AddScoped<ICommandHandler<SkipSessionTrackCommand, bool>, SkipSessionTrackHandler>();
+        services.AddScoped<ICommandHandler<RestartSessionBroadcastCommand, bool>, RestartSessionBroadcastHandler>();
 
         // Register NowPlaying Query Handlers
         services.AddScoped<IQueryHandler<GetNowPlayingQuery, NowPlayingResult>, GetNowPlayingHandler>();
@@ -154,6 +153,7 @@ public static class DependencyInjection
         // Register LiveSession Query Handlers
         services.AddScoped<IQueryHandler<GetLiveSessionQuery, LiveSessionResult>, GetLiveSessionHandler>();
         services.AddScoped<IQueryHandler<GetLiveSessionNowPlayingQuery, StationNowPlayingResult>, GetLiveSessionNowPlayingHandler>();
+        services.AddScoped<IQueryHandler<GetLiveSessionQueueQuery, LiveSessionQueueResult>, GetLiveSessionQueueHandler>();
         services.AddScoped<IQueryHandler<GetAllLiveSessionsQuery, PagedResult<LiveSessionResult>>, GetAllLiveSessionsHandler>();
         services.AddScoped<IQueryHandler<GetSessionSchedulesQuery, List<SessionScheduleResult>>, GetSessionSchedulesHandler>();
         services.AddScoped<IQueryHandler<GetAllSessionSchedulesQuery, List<SessionScheduleResult>>, GetAllSessionSchedulesHandler>();

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/RestartBroadcast/RestartSessionBroadcastCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/RestartBroadcast/RestartSessionBroadcastCommand.cs
@@ -1,0 +1,8 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+
+namespace LiveSessionService.Application.Features.LiveSessions.Commands.RestartBroadcast;
+
+/// <summary>
+/// Command to restart the AzuraCast station broadcast for a live session
+/// </summary>
+public sealed record RestartSessionBroadcastCommand(Guid SessionId) : ICommand<bool>;

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/RestartBroadcast/RestartSessionBroadcastHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/RestartBroadcast/RestartSessionBroadcastHandler.cs
@@ -1,0 +1,50 @@
+using LiveSessionService.Application.Abstractions;
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Domain.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace LiveSessionService.Application.Features.LiveSessions.Commands.RestartBroadcast;
+
+public sealed class RestartSessionBroadcastHandler : ICommandHandler<RestartSessionBroadcastCommand, bool>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IAzuraCastClient _azuraCastClient;
+    private readonly ILogger<RestartSessionBroadcastHandler> _logger;
+
+    public RestartSessionBroadcastHandler(
+        ILiveSessionRepository sessionRepository,
+        IAzuraCastClient azuraCastClient,
+        ILogger<RestartSessionBroadcastHandler> logger)
+    {
+        _sessionRepository = sessionRepository;
+        _azuraCastClient = azuraCastClient;
+        _logger = logger;
+    }
+
+    public async Task<Result<bool>> Handle(RestartSessionBroadcastCommand command, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository.GetByIdWithStationAsync(command.SessionId, cancellationToken);
+        if (session == null)
+            return Result<bool>.Failure("Session not found", ErrorCode.NotFound);
+
+        if (session.AzuraCastStation == null)
+            return Result<bool>.Failure("Session does not have an associated station", ErrorCode.NotFound);
+
+        _logger.LogInformation(
+            "Requesting Restart Station from AzuraCast for session {SessionId} (external station: {ExternalId})",
+            command.SessionId, session.AzuraCastStation.ExternalStationId);
+
+        try
+        {
+            await _azuraCastClient.RestartStationAsync(session.AzuraCastStation.ExternalStationId, cancellationToken);
+            return Result<bool>.Success(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to restart station {StationId}", session.AzuraCastStation.ExternalStationId);
+            return Result<bool>.Failure($"Failed to restart station: {ex.Message}", ErrorCode.InternalServerError);
+        }
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/SkipTrack/SkipSessionTrackCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/SkipTrack/SkipSessionTrackCommand.cs
@@ -1,0 +1,8 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+
+namespace LiveSessionService.Application.Features.LiveSessions.Commands.SkipTrack;
+
+/// <summary>
+/// Command to skip the currently playing track in a live session
+/// </summary>
+public sealed record SkipSessionTrackCommand(Guid SessionId) : ICommand<bool>;

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/SkipTrack/SkipSessionTrackHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Commands/SkipTrack/SkipSessionTrackHandler.cs
@@ -1,0 +1,50 @@
+using LiveSessionService.Application.Abstractions;
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Domain.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace LiveSessionService.Application.Features.LiveSessions.Commands.SkipTrack;
+
+public sealed class SkipSessionTrackHandler : ICommandHandler<SkipSessionTrackCommand, bool>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IAzuraCastClient _azuraCastClient;
+    private readonly ILogger<SkipSessionTrackHandler> _logger;
+
+    public SkipSessionTrackHandler(
+        ILiveSessionRepository sessionRepository,
+        IAzuraCastClient azuraCastClient,
+        ILogger<SkipSessionTrackHandler> logger)
+    {
+        _sessionRepository = sessionRepository;
+        _azuraCastClient = azuraCastClient;
+        _logger = logger;
+    }
+
+    public async Task<Result<bool>> Handle(SkipSessionTrackCommand command, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository.GetByIdWithStationAsync(command.SessionId, cancellationToken);
+        if (session == null)
+            return Result<bool>.Failure("Session not found", ErrorCode.NotFound);
+
+        if (session.AzuraCastStation == null)
+            return Result<bool>.Failure("Session does not have an associated station", ErrorCode.NotFound);
+
+        _logger.LogInformation(
+            "Requesting Skip Track from AzuraCast for session {SessionId} (external station: {ExternalId})",
+            command.SessionId, session.AzuraCastStation.ExternalStationId);
+
+        try
+        {
+            await _azuraCastClient.SkipTrackAsync(session.AzuraCastStation.ExternalStationId, cancellationToken);
+            return Result<bool>.Success(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to skip track for station {StationId}", session.AzuraCastStation.ExternalStationId);
+            return Result<bool>.Failure($"Failed to skip track: {ex.Message}", ErrorCode.InternalServerError);
+        }
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSession/GetLiveSessionHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSession/GetLiveSessionHandler.cs
@@ -55,11 +55,13 @@ public sealed class GetLiveSessionHandler : IQueryHandler<GetLiveSessionQuery, L
         // Fetch now playing data from AzuraCast if session has a station
         NowPlayingTrackResult? currentTrack = null;
         NowPlayingTrackResult? playingNext = null;
+        List<NowPlayingTrackResult> upcomingQueue = [];
         List<NowPlayingTrackResult> songHistory = [];
 
+        AzuraCastNowPlayingData? nowPlayingData = null;
         if (session.AzuraCastStation != null)
         {
-            var nowPlayingData = await _azuraCastClient.GetNowPlayingAsync(
+            nowPlayingData = await _azuraCastClient.GetNowPlayingAsync(
                 session.AzuraCastStation.ExternalStationId, cancellationToken);
 
             if (nowPlayingData != null)
@@ -69,6 +71,8 @@ public sealed class GetLiveSessionHandler : IQueryHandler<GetLiveSessionQuery, L
                 songHistory = nowPlayingData.SongHistory?
                     .Select(MapHistoryTrack)
                     .ToList() ?? [];
+                
+                upcomingQueue = await MapQueueAsync(session.AzuraCastStation.ExternalStationId, cancellationToken);
             }
         }
 
@@ -81,7 +85,10 @@ public sealed class GetLiveSessionHandler : IQueryHandler<GetLiveSessionQuery, L
             PublicPlayerUrl = session.AzuraCastStation?.PublicPlayerUrl,
             CurrentTrack = currentTrack,
             PlayingNext = playingNext,
-            SongHistory = songHistory
+            UpcomingQueue = upcomingQueue,
+            SongHistory = songHistory,
+            TotalListeners = nowPlayingData?.Listeners?.Unique ?? 0,
+            UniqueListeners = nowPlayingData?.Listeners?.Unique ?? 0
         } : null;
 
         var result = new LiveSessionResult
@@ -187,6 +194,26 @@ public sealed class GetLiveSessionHandler : IQueryHandler<GetLiveSessionQuery, L
             Remaining = track.Remaining,
             IsRequest = track.IsRequest
         };
+    }
+
+    private async Task<List<NowPlayingTrackResult>> MapQueueAsync(int externalStationId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var queueData = await _azuraCastClient.GetUpcomingQueueAsync(externalStationId, cancellationToken);
+            if (queueData == null || queueData.Count == 0) return [];
+
+            var mapped = new List<NowPlayingTrackResult>();
+            foreach (var q in queueData)
+            {
+                mapped.Add(await MapTrackAsync(q, cancellationToken));
+            }
+            return mapped;
+        }
+        catch (Exception)
+        {
+            return [];
+        }
     }
 
     private static NowPlayingTrackResult MapHistoryTrack(AzuraCastSongHistoryData h)

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSessionNowPlaying/GetLiveSessionNowPlayingHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSessionNowPlaying/GetLiveSessionNowPlayingHandler.cs
@@ -68,6 +68,7 @@ public sealed class GetLiveSessionNowPlayingHandler
             UniqueListeners   = data.Listeners?.Unique ?? 0,
             CurrentTrack      = data.NowPlaying != null ? await MapTrackAsync(data.NowPlaying, cancellationToken) : null,
             PlayingNext       = data.PlayingNext != null ? await MapTrackAsync(data.PlayingNext, cancellationToken) : null,
+            UpcomingQueue     = await MapQueueAsync(session.AzuraCastStation.ExternalStationId, cancellationToken),
             SongHistory       = data.SongHistory?
                 .Select(MapHistoryTrack)
                 .ToList() ?? []
@@ -134,6 +135,27 @@ public sealed class GetLiveSessionNowPlayingHandler
             Remaining = track.Remaining,
             IsRequest = track.IsRequest
         };
+    }
+
+    private async Task<List<NowPlayingTrackResult>> MapQueueAsync(int externalStationId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var queueData = await _azuraCastClient.GetUpcomingQueueAsync(externalStationId, cancellationToken);
+            if (queueData == null || queueData.Count == 0) return [];
+
+            var mapped = new List<NowPlayingTrackResult>();
+            foreach (var q in queueData)
+            {
+                mapped.Add(await MapTrackAsync(q, cancellationToken));
+            }
+            return mapped;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch upcoming queue for station {ExternalId}", externalStationId);
+            return [];
+        }
     }
 
     private static NowPlayingTrackResult MapHistoryTrack(AzuraCastSongHistoryData track)

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSessionQueue/GetLiveSessionQueueHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSessionQueue/GetLiveSessionQueueHandler.cs
@@ -1,0 +1,127 @@
+using LiveSessionService.Application.Abstractions;
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Common.AzuraCast.Models;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.NowPlaying;
+using LiveSessionService.Domain.Entities;
+using LiveSessionService.Domain.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace LiveSessionService.Application.Features.LiveSessions.Queries.GetLiveSessionQueue;
+
+public sealed class GetLiveSessionQueueHandler
+    : IQueryHandler<GetLiveSessionQueueQuery, LiveSessionQueueResult>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IAzuraCastClient _azuraCastClient;
+    private readonly IMediaFileRepository _mediaFileRepository;
+    private readonly ILogger<GetLiveSessionQueueHandler> _logger;
+
+    public GetLiveSessionQueueHandler(
+        ILiveSessionRepository sessionRepository,
+        IAzuraCastClient azuraCastClient,
+        IMediaFileRepository mediaFileRepository,
+        ILogger<GetLiveSessionQueueHandler> logger)
+    {
+        _sessionRepository = sessionRepository;
+        _azuraCastClient = azuraCastClient;
+        _mediaFileRepository = mediaFileRepository;
+        _logger = logger;
+    }
+
+    public async Task<Result<LiveSessionQueueResult>> Handle(
+        GetLiveSessionQueueQuery query,
+        CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository.GetByIdWithStationAsync(query.SessionId, cancellationToken);
+        if (session == null)
+            return Result<LiveSessionQueueResult>.Failure("Session not found", ErrorCode.NotFound);
+
+        if (session.AzuraCastStation == null)
+            return Result<LiveSessionQueueResult>.Failure("Session does not have an associated station", ErrorCode.NotFound);
+
+        _logger.LogInformation(
+            "Fetching upcoming queue from AzuraCast for session {SessionId} (external station: {ExternalId})",
+            query.SessionId, session.AzuraCastStation.ExternalStationId);
+
+        var queueData = await _azuraCastClient.GetUpcomingQueueAsync(session.AzuraCastStation.ExternalStationId, cancellationToken);
+
+        var mappedQueue = new List<NowPlayingTrackResult>();
+        foreach (var track in queueData)
+        {
+            mappedQueue.Add(await MapTrackAsync(track, cancellationToken));
+        }
+
+        var result = new LiveSessionQueueResult
+        {
+            SessionId = query.SessionId,
+            ExternalStationId = session.AzuraCastStation.ExternalStationId,
+            Queue = mappedQueue
+        };
+
+        return Result<LiveSessionQueueResult>.Success(result);
+    }
+
+    private async Task<NowPlayingTrackResult> MapTrackAsync(AzuraCastCurrentSongData track, CancellationToken cancellationToken)
+    {
+        var lyrics = track.Song?.Lyrics;
+        var artUrl = track.Song?.Art;
+        
+        if ((string.IsNullOrWhiteSpace(lyrics) || string.IsNullOrWhiteSpace(artUrl) || artUrl.Contains("generic_song")))
+        {
+            MediaFile? mediaFile = null;
+
+            if (!string.IsNullOrWhiteSpace(track.Song?.Id))
+            {
+                mediaFile = await _mediaFileRepository.GetByAzuraCastMediaIdAsync(track.Song.Id, cancellationToken);
+            }
+
+            if (mediaFile == null && !string.IsNullOrWhiteSpace(track.Song?.Title))
+            {
+                var files = await _mediaFileRepository.GetAllAsync(cancellationToken);
+                mediaFile = files.FirstOrDefault(f => 
+                    string.Equals(f.Title, track.Song.Title, StringComparison.OrdinalIgnoreCase) && 
+                    (string.IsNullOrWhiteSpace(track.Song.Artist) || string.Equals(f.Artist, track.Song.Artist, StringComparison.OrdinalIgnoreCase))
+                );
+            }
+
+            if (mediaFile != null)
+            {
+                if (string.IsNullOrWhiteSpace(lyrics) && !string.IsNullOrWhiteSpace(mediaFile.Lyrics))
+                    lyrics = mediaFile.Lyrics;
+                
+                if ((string.IsNullOrWhiteSpace(artUrl) || artUrl.Contains("generic_song")) 
+                    && !string.IsNullOrWhiteSpace(mediaFile.ArtUrl))
+                    artUrl = mediaFile.ArtUrl;
+            }
+        }
+
+        return new NowPlayingTrackResult
+        {
+            ShId      = track.ShId,
+            Text      = track.Song?.Text,
+            Title     = track.Song?.Title,
+            Artist    = track.Song?.Artist,
+            Album     = track.Song?.Album,
+            Genre     = track.Song?.Genre,
+            ArtUrl    = ResolveHttpsUrl(artUrl),
+            Lyrics    = lyrics,
+            PlayedAt  = track.PlayedAt,
+            Duration  = track.Duration,
+            Elapsed   = track.Elapsed,
+            Remaining = track.Remaining,
+            IsRequest = track.IsRequest
+        };
+    }
+
+    private static string? ResolveHttpsUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return url;
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            return "https://" + url.Substring(7);
+        }
+        return url;
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSessionQueue/GetLiveSessionQueueQuery.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetLiveSessionQueue/GetLiveSessionQueueQuery.cs
@@ -1,0 +1,9 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.NowPlaying;
+
+namespace LiveSessionService.Application.Features.LiveSessions.Queries.GetLiveSessionQueue;
+
+/// <summary>
+/// Query to get real-time upcoming queue data for a live session from AzuraCast
+/// </summary>
+public sealed record GetLiveSessionQueueQuery(Guid SessionId) : IQuery<LiveSessionQueueResult>;

--- a/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetStaffDashboardOverview/GetStaffDashboardOverviewHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/LiveSessions/Queries/GetStaffDashboardOverview/GetStaffDashboardOverviewHandler.cs
@@ -25,13 +25,8 @@ public sealed class GetStaffDashboardOverviewHandler : IQueryHandler<GetStaffDas
         var normalizedDays = query.Days <= 0 ? 7 : Math.Min(query.Days, 90);
         var utcToday = DateTime.UtcNow.Date;
 
-        var stationsTask = _stationRepository.GetAllEnabledAsync(cancellationToken);
-        var dashboardTask = _liveSessionRepository.GetStaffDashboardOverviewAsync(normalizedDays, cancellationToken);
-
-        await Task.WhenAll(stationsTask, dashboardTask);
-
-        var stations = stationsTask.Result;
-        var dashboard = dashboardTask.Result;
+        var stations = await _stationRepository.GetAllEnabledAsync(cancellationToken);
+        var dashboard = await _liveSessionRepository.GetStaffDashboardOverviewAsync(normalizedDays, cancellationToken);
 
         var result = new StaffDashboardOverviewResult
         {

--- a/services/live-session-service/LiveSessionService.Application/Features/Results/NowPlaying/LiveSessionQueueResult.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Results/NowPlaying/LiveSessionQueueResult.cs
@@ -1,0 +1,8 @@
+namespace LiveSessionService.Application.Features.Results.NowPlaying;
+
+public sealed class LiveSessionQueueResult
+{
+    public Guid SessionId { get; init; }
+    public int ExternalStationId { get; init; }
+    public List<NowPlayingTrackResult> Queue { get; init; } = [];
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Results/NowPlaying/StationNowPlayingResult.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Results/NowPlaying/StationNowPlayingResult.cs
@@ -14,6 +14,7 @@ public sealed class StationNowPlayingResult
     public int UniqueListeners { get; init; }
     public NowPlayingTrackResult? CurrentTrack { get; init; }
     public NowPlayingTrackResult? PlayingNext { get; init; }
+    public List<NowPlayingTrackResult> UpcomingQueue { get; init; } = [];
     public List<NowPlayingTrackResult> SongHistory { get; init; } = [];
 }
 

--- a/services/live-session-service/LiveSessionService.Application/Features/Stations/Queries/GetStationNowPlaying/GetStationNowPlayingHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Stations/Queries/GetStationNowPlaying/GetStationNowPlayingHandler.cs
@@ -73,10 +73,11 @@ public sealed class GetStationNowPlayingHandler
             IsOnline          = data.IsOnline,
             IsLive            = data.IsLive,
             StreamerName      = data.StreamerName,
-            TotalListeners    = data.Listeners?.Total ?? 0,
+            TotalListeners    = data.Listeners?.Unique ?? 0,
             UniqueListeners   = data.Listeners?.Unique ?? 0,
             CurrentTrack      = data.NowPlaying != null ? await MapTrackAsync(data.NowPlaying, cancellationToken) : null,
             PlayingNext       = data.PlayingNext != null ? await MapTrackAsync(data.PlayingNext, cancellationToken) : null,
+            UpcomingQueue     = await MapQueueAsync(station.ExternalStationId, cancellationToken),
             SongHistory       = data.SongHistory?
                 .Select(MapHistoryTrack)
                 .ToList() ?? []
@@ -143,6 +144,27 @@ public sealed class GetStationNowPlayingHandler
             Remaining = track.Remaining,
             IsRequest = track.IsRequest
         };
+    }
+
+    private async Task<List<NowPlayingTrackResult>> MapQueueAsync(int externalStationId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var queueData = await _azuraCastClient.GetUpcomingQueueAsync(externalStationId, cancellationToken);
+            if (queueData == null || queueData.Count == 0) return [];
+
+            var mapped = new List<NowPlayingTrackResult>();
+            foreach (var q in queueData)
+            {
+                mapped.Add(await MapTrackAsync(q, cancellationToken));
+            }
+            return mapped;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch upcoming queue for station {ExternalId}", externalStationId);
+            return [];
+        }
     }
 
     private static NowPlayingTrackResult MapHistoryTrack(AzuraCastSongHistoryData h)

--- a/services/live-session-service/LiveSessionService.Infrastructure/Repositories/LiveSessionRepository.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Repositories/LiveSessionRepository.cs
@@ -89,8 +89,8 @@ public sealed class LiveSessionRepository : ILiveSessionRepository
         var utcToday = DateTime.UtcNow.Date;
         var fromDate = utcToday.AddDays(-(normalizedDays - 1));
 
-        var totalSessionsTask = _context.LiveSessions.CountAsync(cancellationToken);
-        var liveSessionsTask = _context.LiveSessions.CountAsync(
+        var totalSessions = await _context.LiveSessions.CountAsync(cancellationToken);
+        var liveSessions = await _context.LiveSessions.CountAsync(
             x => x.Status == Domain.Enums.SessionStatus.Live,
             cancellationToken);
 
@@ -99,8 +99,6 @@ public sealed class LiveSessionRepository : ILiveSessionRepository
             .Where(x => x.ConnectedAt >= fromDate)
             .Select(x => new { x.Id, x.ConnectedAt, x.UserId, x.AnonymousIdentifier })
             .ToListAsync(cancellationToken);
-
-        await Task.WhenAll(totalSessionsTask, liveSessionsTask);
 
         string ToListenerKey(Guid id, Guid? userId, string? anonymousIdentifier)
         {
@@ -141,8 +139,8 @@ public sealed class LiveSessionRepository : ILiveSessionRepository
 
         return new StaffDashboardOverview
         {
-            TotalSessions = totalSessionsTask.Result,
-            LiveSessions = liveSessionsTask.Result,
+            TotalSessions = totalSessions,
+            LiveSessions = liveSessions,
             ListenersToday = listenersToday,
             DailyListeners = dailyListeners
         };

--- a/services/live-session-service/LiveSessionService.Infrastructure/Services/AzuraCast/AzuraCastClient.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Services/AzuraCast/AzuraCastClient.cs
@@ -597,6 +597,43 @@ public sealed class AzuraCastClient : IAzuraCastClient
             stationId);
     }
 
+    public async Task SkipTrackAsync(int stationId, CancellationToken cancellationToken = default)
+    {
+        var endpoint = $"api/station/{stationId}/backend/skip";
+        _logger.LogInformation("Skipping track for station {StationId}", stationId);
+
+        using var response = await _httpClient.PostAsync(endpoint, null, cancellationToken);
+        await EnsureAzuraCastSuccessAsync(response, $"skip track for station {stationId}", cancellationToken);
+
+        _logger.LogInformation("Successfully skipped track for station {StationId}", stationId);
+    }
+
+    public async Task<List<AzuraCastCurrentSongData>> GetUpcomingQueueAsync(int stationId, CancellationToken cancellationToken = default)
+    {
+        var endpoint = $"api/station/{stationId}/queue";
+        _logger.LogInformation("Fetching upcoming queue for station {StationId}", stationId);
+
+        var apiResponse = await _httpClient.GetFromJsonAsync<List<AzuraCastApiNowPlaying>>(endpoint, cancellationToken);
+
+        if (apiResponse == null)
+        {
+            return new List<AzuraCastCurrentSongData>();
+        }
+
+        return apiResponse.Select(q => q.ToApplicationModel()).ToList();
+    }
+
+    public async Task RestartStationAsync(int stationId, CancellationToken cancellationToken = default)
+    {
+        var endpoint = $"api/station/{stationId}/restart";
+        _logger.LogInformation("Restarting station {StationId}", stationId);
+
+        using var response = await _httpClient.PostAsync(endpoint, null, cancellationToken);
+        await EnsureAzuraCastSuccessAsync(response, $"restart station {stationId}", cancellationToken);
+
+        _logger.LogInformation("Successfully requested restart for station {StationId}", stationId);
+    }
+
     public async Task<(byte[] Content, string? ContentType, string? FileName)?> DownloadMediaAsync(
         int stationId,
         string fileUniqueId,

--- a/services/live-session-service/LiveSessionService.Infrastructure/Services/AzuraCast/Mappers/AzuraCastMapper.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Services/AzuraCast/Mappers/AzuraCastMapper.cs
@@ -60,7 +60,7 @@ internal static class AzuraCastMapper
             Mounts = api.Mounts?.Select(m => m.ToApplicationModel()).ToList()
         };
 
-    private static AzuraCastCurrentSongData ToApplicationModel(this AzuraCastApiNowPlaying api)
+    internal static AzuraCastCurrentSongData ToApplicationModel(this AzuraCastApiNowPlaying api)
         => new()
         {
             ShId      = api.ShId,


### PR DESCRIPTION
Expose user public profile endpoints and make posts public-facing; add live-session queue and station control features.

- API gateway: added routes for user posts, saved podcasts, user playlists and favorites.
- AccountContentService: allow anonymous access to GET user posts and only return published/public posts (new repository method GetPublishedByUserIdAsync and implementation); added a new theme to DataSeeder.
- AuthQueryService: added GET /public-profile endpoint that strips sensitive fields for non-owners, converted UserFullProfileDto to a record and added ResolveUserId helper.
- LiveSessionService (API + Application + Infrastructure):
  - Controllers: added endpoints to fetch session queue, skip track and restart station; added user playlist and saved-podcasts user lookup endpoints.
  - Application: added commands/handlers for SkipSessionTrack and RestartSessionBroadcast, query/handler/result for GetLiveSessionQueue, extended results (UpcomingQueue, LiveSessionQueueResult) and integrated queue mapping into now-playing handlers.
  - IAzuraCastClient: added SkipTrackAsync, GetUpcomingQueueAsync and RestartStationAsync; implemented them in AzuraCastClient and updated mapper visibility.
  - Dependency injection: registered new handlers and query handler.
  - Repository/perf: simplified awaiting in staff dashboard/live session repository counts.
  - Added mapping logic to enrich queue tracks with media metadata.

These changes add real-time queue visibility and station control via AzuraCast, expose select public user data safely, and ensure only published blog posts are returned for public endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public user profile endpoint accessible without authentication
  * Added public endpoints for viewing user posts, saved podcasts, and playlists
  * Added live session queue retrieval for broadcast monitoring
  * Added live broadcast controls to skip track and restart broadcast
  * Added "Sunset Balcony Theme" to available themes

* **Changes**
  * Published posts are now viewable by anonymous users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->