### PR TITLE
(feat): Add manual script creation and public playlists

### DIFF
--- a/services/ai-service/AiService.Api/Controllers/ScriptsController.cs
+++ b/services/ai-service/AiService.Api/Controllers/ScriptsController.cs
@@ -3,6 +3,7 @@ using AiService.Api.Models.Requests.Scripts;
 using AiService.Api.Models.Responses;
 using AiService.Application.Abstractions.Messaging.Dispatcher.Interfaces;
 using AiService.Application.Enums;
+using AiService.Application.Features.Scripts.Commands.CreateManualScript;
 using AiService.Application.Features.Scripts.Commands.GeneratePodcastScript;
 using AiService.Application.Features.Scripts.Commands.SplitScript;
 using AiService.Application.Features.Scripts.Commands.DeleteScript;
@@ -11,6 +12,7 @@ using AiService.Application.Features.Scripts.Queries.GetMyScripts;
 using AiService.Application.Features.Scripts.Queries.GetScriptById;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+
 
 namespace AiService.Api.Controllers;
 
@@ -53,6 +55,27 @@ public class ScriptsController : ControllerBase
                 request.EditorInstruction,
                 request.UseAutoContext,
                 request.StrictFactMode),
+            cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(ApiResponse<object>.SuccessResponse(new { script = result.Data }))
+            : BadRequest(ApiResponse<string>.Error(ApiStatusCode.HB40001, result.ErrorMessage ?? "Failed"));
+    }
+
+    /// <summary>
+    /// Create a script manually from user-provided content — no AI involved.
+    /// </summary>
+    [HttpPost]
+    public async Task<IActionResult> CreateManual([FromBody] CreateManualScriptRequest request, CancellationToken cancellationToken)
+    {
+        if (!User.TryGetCurrentUserId(out var userId))
+            return Unauthorized(ApiResponse<string>.Error(ApiStatusCode.HB40101, "Invalid token"));
+
+        if (string.IsNullOrWhiteSpace(request.ContentText))
+            return BadRequest(ApiResponse<string>.Error(ApiStatusCode.HB40001, "contentText is required"));
+
+        var result = await _commands.Send<CreateManualScriptCommand, Domain.Entities.Script>(
+            new CreateManualScriptCommand(userId, request.ContentText, request.Title, request.Topic),
             cancellationToken);
 
         return result.IsSuccess

--- a/services/ai-service/AiService.Api/Models/Requests/Scripts/CreateManualScriptRequest.cs
+++ b/services/ai-service/AiService.Api/Models/Requests/Scripts/CreateManualScriptRequest.cs
@@ -1,0 +1,8 @@
+namespace AiService.Api.Models.Requests.Scripts;
+
+public class CreateManualScriptRequest
+{
+    public required string ContentText { get; set; }
+    public string? Title { get; set; }
+    public string? Topic { get; set; }
+}

--- a/services/ai-service/AiService.Application/DependencyInjection.cs
+++ b/services/ai-service/AiService.Application/DependencyInjection.cs
@@ -2,10 +2,12 @@ using AiService.Application.Abstractions.Messaging.Dispatcher;
 using AiService.Application.Abstractions.Messaging.Dispatcher.Interfaces;
 using AiService.Application.Features.Audios.Commands.GenerateAudio;
 using AiService.Application.Features.Audios.Queries.GetAudioById;
+using AiService.Application.Features.Scripts.Commands.CreateManualScript;
 using AiService.Application.Features.Scripts.Commands.GeneratePodcastScript;
 using AiService.Application.Features.Scripts.Commands.SplitScript;
 using AiService.Application.Features.Scripts.Commands.DeleteScript;
 using AiService.Application.Features.Scripts.Commands.UpdateScript;
+
 using AiService.Application.Features.Scripts.Queries.GetMyScripts;
 using AiService.Application.Features.Scripts.Queries.GetScriptById;
 using AiService.Application.Features.Voices.Commands.CreateVoice;
@@ -34,6 +36,7 @@ public static class DependencyInjection
         services.AddScoped<IPodcastGenerationService, PodcastGenerationService>();
 
         // Handlers
+        services.AddScoped<Abstractions.Messaging.ICommandHandler<CreateManualScriptCommand, Domain.Entities.Script>, CreateManualScriptHandler>();
         services.AddScoped<Abstractions.Messaging.ICommandHandler<GeneratePodcastScriptCommand, Domain.Entities.Script>, GeneratePodcastScriptHandler>();
         services.AddScoped<Abstractions.Messaging.ICommandHandler<SplitScriptPartsCommand, IReadOnlyList<Domain.Entities.Script>>, SplitScriptPartsHandler>();
         services.AddScoped<Abstractions.Messaging.ICommandHandler<DeleteScriptCommand, bool>, DeleteScriptHandler>();

--- a/services/ai-service/AiService.Application/Features/Scripts/Commands/CreateManualScript/CreateManualScriptCommand.cs
+++ b/services/ai-service/AiService.Application/Features/Scripts/Commands/CreateManualScript/CreateManualScriptCommand.cs
@@ -1,0 +1,9 @@
+using AiService.Application.Abstractions.Messaging;
+
+namespace AiService.Application.Features.Scripts.Commands.CreateManualScript;
+
+public record CreateManualScriptCommand(
+    Guid UserId,
+    string ContentText,
+    string? Title,
+    string? Topic) : ICommand<Domain.Entities.Script>;

--- a/services/ai-service/AiService.Application/Features/Scripts/Commands/CreateManualScript/CreateManualScriptHandler.cs
+++ b/services/ai-service/AiService.Application/Features/Scripts/Commands/CreateManualScript/CreateManualScriptHandler.cs
@@ -1,0 +1,18 @@
+using AiService.Application.Abstractions.Messaging;
+using AiService.Application.Interfaces;
+using AiService.Application.Results;
+
+namespace AiService.Application.Features.Scripts.Commands.CreateManualScript;
+
+public class CreateManualScriptHandler : ICommandHandler<CreateManualScriptCommand, Domain.Entities.Script>
+{
+    private readonly IScriptService _scripts;
+
+    public CreateManualScriptHandler(IScriptService scripts)
+    {
+        _scripts = scripts;
+    }
+
+    public Task<Result<Domain.Entities.Script>> Handle(CreateManualScriptCommand command, CancellationToken cancellationToken)
+        => _scripts.CreateManualAsync(command.UserId, command.ContentText, command.Title, command.Topic, cancellationToken);
+}

--- a/services/ai-service/AiService.Application/Interfaces/IScriptService.cs
+++ b/services/ai-service/AiService.Application/Interfaces/IScriptService.cs
@@ -28,5 +28,6 @@ public interface IScriptService
     Task<Result<IReadOnlyList<Script>>> GetMyScriptsAsync(Guid userId, string? contextType, string? status, CancellationToken cancellationToken);
     Task<Result<bool>> DeleteAsync(Guid userId, Guid scriptId, CancellationToken cancellationToken);
     Task<Result<bool>> UpdateAsync(Guid userId, Guid scriptId, string? title, string? contentText, CancellationToken cancellationToken);
+    Task<Result<Script>> CreateManualAsync(Guid userId, string contentText, string? title, string? topic, CancellationToken cancellationToken);
 }
 

--- a/services/ai-service/AiService.Application/Services/ScriptService.cs
+++ b/services/ai-service/AiService.Application/Services/ScriptService.cs
@@ -196,6 +196,33 @@ public class ScriptService : IScriptService
         return Result<bool>.Success(true);
     }
 
+    /// <summary>
+    /// Creates a script directly from user-provided content, bypassing AI generation entirely.
+    /// </summary>
+    public async Task<Result<Script>> CreateManualAsync(Guid userId, string contentText, string? title, string? topic, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(contentText))
+            return Result<Script>.Failure("contentText is required");
+
+        var script = new Script
+        {
+            ScriptId = Guid.NewGuid(),
+            AuthorId = userId,
+            ScriptSource = "manual",
+            ContextType = "podcast",
+            Title = string.IsNullOrWhiteSpace(title) ? null : title.Trim(),
+            ContentText = contentText.Trim(),
+            Status = Domain.Enums.ScriptStatus.Generated.ToString().ToLowerInvariant(),
+            PromptId = null,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _scripts.AddAsync(script, cancellationToken);
+        await _uow.SaveChangesAsync(cancellationToken);
+
+        return Result<Script>.Success(script);
+    }
+
     private static List<string> SplitByMaxChars(string text, int maxChars)
     {
         var parts = new List<string>();

--- a/services/live-session-service/LiveSessionService.Api/Controllers/MusicCatalogController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/MusicCatalogController.cs
@@ -56,6 +56,7 @@ public class MusicCatalogController : ControllerBase
     /// Supports direct HTTP file URLs and AzuraCast unique_id-based media.
     /// </summary>
     [HttpGet("{id:guid}/stream")]
+    [AllowAnonymous]
     [ProducesResponseType(200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
     public async Task<IActionResult> StreamById(Guid id, CancellationToken ct)
@@ -114,6 +115,7 @@ public class MusicCatalogController : ControllerBase
     /// Get all media files in music catalog
     /// </summary>
     [HttpGet]
+    [AllowAnonymous]
     [ProducesResponseType(typeof(ApiResponse<List<MusicResult>>), 200)]
     public async Task<IActionResult> GetAllMusic(CancellationToken ct)
     {

--- a/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/UserPlaylistController.cs
@@ -10,6 +10,7 @@ using LiveSessionService.Application.Features.Playlists.Commands.RemoveTracksFro
 using LiveSessionService.Application.Features.Playlists.Commands.UpdateUserPlaylist;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistTracks;
+using LiveSessionService.Application.Features.Playlists.Queries.GetPublicUserPlaylistsByUserId;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
 using LiveSessionService.Application.Features.Results.Playlists;
 using Microsoft.AspNetCore.Authorization;
@@ -67,8 +68,8 @@ public sealed class UserPlaylistController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<List<UserPlaylistResult>>), 200)]
     public async Task<IActionResult> GetByUserId(Guid userId, CancellationToken ct)
     {
-        var result = await _queries.Send<GetUserPlaylistsQuery, List<UserPlaylistResult>>(
-            new GetUserPlaylistsQuery(userId),
+        var result = await _queries.Send<GetPublicUserPlaylistsByUserIdQuery, List<UserPlaylistResult>>(
+            new GetPublicUserPlaylistsByUserIdQuery(userId),
             ct);
 
         return Ok(result.ToApiResponse());
@@ -98,19 +99,17 @@ public sealed class UserPlaylistController : ControllerBase
     /// <param name="ct"></param>
     /// <returns></returns>
     [HttpGet("{id:guid}")]
+    [AllowAnonymous]
     [ProducesResponseType(typeof(ApiResponse<UserPlaylistResult>), 200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 401)]
     [ProducesResponseType(typeof(ApiResponse<object>), 403)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
     public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
     {
-        if (!TryGetCurrentUserId(out var userId))
-        {
-            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
-        }
+        TryGetCurrentUserId(out var userId);
 
         var result = await _queries.Send<GetUserPlaylistByIdQuery, UserPlaylistResult>(
-            new GetUserPlaylistByIdQuery(id, userId),
+            new GetUserPlaylistByIdQuery(id, userId == Guid.Empty ? null : userId),
             ct);
 
         if (!result.IsSuccess)
@@ -253,19 +252,17 @@ public sealed class UserPlaylistController : ControllerBase
     /// Get all tracks of a user playlist for the current user
     /// </summary>
     [HttpGet("{id:guid}/tracks")]
+    [AllowAnonymous]
     [ProducesResponseType(typeof(ApiResponse<List<PlaylistMediaResult>>), 200)]
     [ProducesResponseType(typeof(ApiResponse<object>), 401)]
     [ProducesResponseType(typeof(ApiResponse<object>), 403)]
     [ProducesResponseType(typeof(ApiResponse<object>), 404)]
     public async Task<IActionResult> GetTracks(Guid id, CancellationToken ct)
     {
-        if (!TryGetCurrentUserId(out var userId))
-        {
-            return Unauthorized(ApiResponse<object>.FailureResponse("Invalid or missing user token", (int)ErrorCode.Unauthorized));
-        }
+        TryGetCurrentUserId(out var userId);
 
         var result = await _queries.Send<GetUserPlaylistTracksQuery, List<PlaylistMediaResult>>(
-            new GetUserPlaylistTracksQuery(id, userId),
+            new GetUserPlaylistTracksQuery(id, userId == Guid.Empty ? null : userId),
             ct);
 
         if (!result.IsSuccess)

--- a/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
@@ -56,6 +56,7 @@ using LiveSessionService.Application.Features.Playlists.Queries.GetAllPublicUser
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylists;
 using LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistTracks;
+using LiveSessionService.Application.Features.Playlists.Queries.GetPublicUserPlaylistsByUserId;
 using LiveSessionService.Application.Features.Podcasts.Commands.CreatePodcast;
 using LiveSessionService.Application.Features.Podcasts.Commands.CreatePodcastEpisode;
 using LiveSessionService.Application.Features.Podcasts.Commands.DeletePodcast;
@@ -172,6 +173,7 @@ public static class DependencyInjection
         services.AddScoped<IQueryHandler<GetPlaylistsByStationQuery, List<PlaylistResult>>, GetPlaylistsByStationHandler>();
         services.AddScoped<IQueryHandler<GetAllPublicUserPlaylistsQuery, List<UserPlaylistResult>>, GetAllPublicUserPlaylistsHandler>();
         services.AddScoped<IQueryHandler<GetUserPlaylistsQuery, List<UserPlaylistResult>>, GetUserPlaylistsHandler>();
+        services.AddScoped<IQueryHandler<GetPublicUserPlaylistsByUserIdQuery, List<UserPlaylistResult>>, GetPublicUserPlaylistsByUserIdHandler>();
         services.AddScoped<IQueryHandler<GetUserPlaylistByIdQuery, UserPlaylistResult>, GetUserPlaylistByIdHandler>();
         services.AddScoped<IQueryHandler<GetPlaylistTracksQuery, List<PlaylistMediaResult>>, GetPlaylistTracksHandler>();
         services.AddScoped<IQueryHandler<GetUserPlaylistTracksQuery, List<PlaylistMediaResult>>, GetUserPlaylistTracksHandler>();

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetPublicUserPlaylistsByUserId/GetPublicUserPlaylistsByUserIdHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetPublicUserPlaylistsByUserId/GetPublicUserPlaylistsByUserIdHandler.cs
@@ -1,0 +1,37 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Application.Features.Results.Playlists;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetPublicUserPlaylistsByUserId;
+
+public sealed class GetPublicUserPlaylistsByUserIdHandler : IQueryHandler<GetPublicUserPlaylistsByUserIdQuery, List<UserPlaylistResult>>
+{
+    private readonly IUserPlaylistRepository _userPlaylistRepository;
+
+    public GetPublicUserPlaylistsByUserIdHandler(IUserPlaylistRepository userPlaylistRepository)
+    {
+        _userPlaylistRepository = userPlaylistRepository;
+    }
+
+    public async Task<Result<List<UserPlaylistResult>>> Handle(GetPublicUserPlaylistsByUserIdQuery query, CancellationToken cancellationToken)
+    {
+        var playlists = await _userPlaylistRepository.GetPublicPlaylistsByUserIdAsync(query.UserId, cancellationToken);
+
+        var results = playlists.Select(x => new UserPlaylistResult
+        {
+            Id = x.Id,
+            UserId = x.UserId,
+            PlaylistName = x.PlaylistName,
+            Description = x.Description,
+            ThumbnailUrl = x.ThumbnailUrl,
+            Visibility = x.Visibility,
+            IsEnabled = x.IsEnabled,
+            TotalTracks = x.UserPlaylistMedias.Count,
+            CreatedAt = x.CreatedAt,
+            UpdatedAt = x.UpdatedAt
+        }).ToList();
+
+        return Result<List<UserPlaylistResult>>.Success(results);
+    }
+}

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetPublicUserPlaylistsByUserId/GetPublicUserPlaylistsByUserIdQuery.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetPublicUserPlaylistsByUserId/GetPublicUserPlaylistsByUserIdQuery.cs
@@ -1,0 +1,6 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Features.Results.Playlists;
+
+namespace LiveSessionService.Application.Features.Playlists.Queries.GetPublicUserPlaylistsByUserId;
+
+public sealed record GetPublicUserPlaylistsByUserIdQuery(Guid UserId) : IQuery<List<UserPlaylistResult>>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdHandler.cs
@@ -23,7 +23,7 @@ public sealed class GetUserPlaylistByIdHandler : IQueryHandler<GetUserPlaylistBy
             return Result<UserPlaylistResult>.Failure("Playlist not found", ErrorCode.NotFound);
         }
 
-        if (playlist.UserId != query.UserId)
+        if (playlist.UserId != query.UserId && playlist.Visibility != LiveSessionService.Domain.Enums.PlaylistVisibility.Public)
         {
             return Result<UserPlaylistResult>.Failure("You do not have permission to access this playlist", ErrorCode.Forbidden);
         }

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdQuery.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistById/GetUserPlaylistByIdQuery.cs
@@ -3,4 +3,4 @@ using LiveSessionService.Application.Features.Results.Playlists;
 
 namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistById;
 
-public sealed record GetUserPlaylistByIdQuery(Guid PlaylistId, Guid UserId) : IQuery<UserPlaylistResult>;
+public sealed record GetUserPlaylistByIdQuery(Guid PlaylistId, Guid? UserId) : IQuery<UserPlaylistResult>;

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksHandler.cs
@@ -23,7 +23,7 @@ public sealed class GetUserPlaylistTracksHandler : IQueryHandler<GetUserPlaylist
             return Result<List<PlaylistMediaResult>>.Failure("Playlist not found", ErrorCode.NotFound);
         }
 
-        if (playlist.UserId != query.UserId)
+        if (playlist.UserId != query.UserId && playlist.Visibility != LiveSessionService.Domain.Enums.PlaylistVisibility.Public)
         {
             return Result<List<PlaylistMediaResult>>.Failure("You do not have permission to access this playlist", ErrorCode.Forbidden);
         }

--- a/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksQuery.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/Playlists/Queries/GetUserPlaylistTracks/GetUserPlaylistTracksQuery.cs
@@ -3,4 +3,4 @@ using LiveSessionService.Application.Features.Results.Playlists;
 
 namespace LiveSessionService.Application.Features.Playlists.Queries.GetUserPlaylistTracks;
 
-public sealed record GetUserPlaylistTracksQuery(Guid PlaylistId, Guid UserId) : IQuery<List<PlaylistMediaResult>>;
+public sealed record GetUserPlaylistTracksQuery(Guid PlaylistId, Guid? UserId) : IQuery<List<PlaylistMediaResult>>;

--- a/services/live-session-service/LiveSessionService.Domain/Interfaces/IUserPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Domain/Interfaces/IUserPlaylistRepository.cs
@@ -13,4 +13,5 @@ public interface IUserPlaylistRepository
     Task AddTracksAsync(IEnumerable<UserPlaylistMedia> tracks, CancellationToken cancellationToken = default);
     Task RemoveTracksAsync(IEnumerable<UserPlaylistMedia> tracks, CancellationToken cancellationToken = default);
     Task<List<UserPlaylistMedia>> GetTracksAsync(Guid playlistId, CancellationToken cancellationToken = default);
+    Task<List<UserPlaylist>> GetPublicPlaylistsByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/services/live-session-service/LiveSessionService.Infrastructure/Repositories/UserPlaylistRepository.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Repositories/UserPlaylistRepository.cs
@@ -71,4 +71,11 @@ public sealed class UserPlaylistRepository : IUserPlaylistRepository
             .Where(x => x.UserPlaylistId == playlistId)
             .OrderByDescending(x => x.CreatedAt)
             .ToListAsync(cancellationToken);
+
+    public Task<List<UserPlaylist>> GetPublicPlaylistsByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+        => _db.UserPlaylists
+            .Include(x => x.UserPlaylistMedias)
+            .Where(x => x.UserId == userId && x.Visibility == LiveSessionService.Domain.Enums.PlaylistVisibility.Public && x.IsEnabled)
+            .OrderByDescending(x => x.CreatedAt)
+            .ToListAsync(cancellationToken);
 }


### PR DESCRIPTION
AI service: add CreateManual endpoint and DTO to create scripts from user-provided content (no AI). Introduce CreateManualScript command/handler, register handler in DI, add IScriptService.CreateManualAsync and implement it in ScriptService to persist manual scripts.

Live-session service: expose music catalog and playlist endpoints to anonymous users, allow nullable userId for playlist queries, and update permission checks to permit public playlists. Add GetPublicUserPlaylistsByUserId query/handler, register it in DI, and add GetPublicPlaylistsByUserIdAsync to the user playlist repository and its implementation.