### PR TITLE
(fix): Set TTS model before streaming; refine voice fallback

### DIFF
--- a/services/ai-service/AiService.Infrastructure/Clients/VieNeuTtsClient.cs
+++ b/services/ai-service/AiService.Infrastructure/Clients/VieNeuTtsClient.cs
@@ -481,8 +481,33 @@ public class VieNeuTtsClient : ITtsClient
 
     private async Task<TtsSynthesizeResponse?> TrySynthesizeViaStreamAsync(string baseUrl, TtsSynthesizeRequest request, CancellationToken cancellationToken)
     {
+        var ttsModel = string.IsNullOrWhiteSpace(request.Model) || request.Model.StartsWith("${")
+            ? _options.Model
+            : request.Model;
+
         foreach (var candidateBaseUrl in GetStreamCandidates(baseUrl))
         {
+            if (!string.IsNullOrWhiteSpace(ttsModel))
+            {
+                try
+                {
+                    var setModelPayload = new { model_key = ttsModel };
+                    using var setModelRequest = new HttpRequestMessage(HttpMethod.Post, BuildUri(candidateBaseUrl, "/set_model"))
+                    {
+                        Content = JsonContent.Create(setModelPayload, options: JsonOptions)
+                    };
+                    if (!string.IsNullOrWhiteSpace(_options.ApiKey) && !_options.ApiKey.StartsWith("${"))
+                        setModelRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.ApiKey);
+                    
+                    // Fire and forget or await briefly
+                    await _http.SendAsync(setModelRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                }
+                catch
+                {
+                    // Ignore set_model failures (might not be supported on all versions)
+                }
+            }
+
             // Try POST /stream first (supports long text and avoids URL encoding limits).
             var postResult = await TryCallStreamPostAsync(candidateBaseUrl, request, cancellationToken);
             if (postResult is not null)

--- a/services/ai-service/AiService.Infrastructure/Services/VieneuTextToSpeechService.cs
+++ b/services/ai-service/AiService.Infrastructure/Services/VieneuTextToSpeechService.cs
@@ -54,23 +54,17 @@ public class VieneuTextToSpeechService : ITextToSpeechService
 
         if (voice == null)
         {
-            // Fallback to q4 baseline
-            voiceCodeToUse = "q4";
-            _logger.LogWarning("[TTS] Cloned voice not found in DB, falling back to 'q4'");
-            voice = await _voiceRepository.GetByCodeAsync(AiProviderConstants.VieNeuTts, voiceCodeToUse, cancellationToken);
-
-            // If still null, try to take the first active one
-            if (voice == null)
+            if (!string.IsNullOrWhiteSpace(request.Voice))
             {
-                var activeVoices = await _voiceRepository.GetActiveAsync(cancellationToken);
-                voice = activeVoices.FirstOrDefault();
-                if (voice != null)
-                {
-                    voiceCodeToUse = voice.VoiceCode;
-                    _logger.LogWarning("[TTS] Fallback 'q4' not found either. Using first active voice: '{Name}' ({Code})",
-                        voice.DisplayName, voice.VoiceCode);
-                }
+                return Result<TextToSpeechResult>.Failure($"Voice '{request.Voice}' not found", (int)ApiStatusCode.HB40401);
             }
+            
+            // Fallback to q4 baseline only if no voice was specifically requested
+            voiceCodeToUse = "q4";
+            voice = await _voiceRepository.GetByCodeAsync(AiProviderConstants.VieNeuTts, "q4", cancellationToken);
+            
+            if (voice == null)
+                return Result<TextToSpeechResult>.Failure("Baseline voice 'q4' not found in database", (int)ApiStatusCode.HB50001);
         }
 
         _logger.LogInformation(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text-to-speech now explicitly configures the selected model before initiating audio synthesis.

* **Bug Fixes**
  * Voice selection is now stricter: when a requested voice is unavailable, the service returns a specific error code instead of automatically falling back to alternative voices. Only the default voice can be used as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->