### PR TITLE
(feat): Add audio chunking, concat and moderation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,6 +225,7 @@ services:
       - Cloudinary__CloudName=${CLOUDINARY_CLOUD_NAME}
       - Cloudinary__ApiKey=${CLOUDINARY_API_KEY}
       - Cloudinary__ApiSecret=${CLOUDINARY_API_SECRET}
+      - GOOGLE_CREDENTIALS_BASE64=${GOOGLE_CREDENTIALS_BASE64}
     ports:
       - "8003:8080"
     depends_on:

--- a/services/ai-service/AiService.Api/Extensions/MigrationExtensions.cs
+++ b/services/ai-service/AiService.Api/Extensions/MigrationExtensions.cs
@@ -80,15 +80,36 @@ public static class MigrationExtensions
 
             var defaultVoices = new List<AiService.Domain.Entities.TtsVoice>
             {
-                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "ngochuyen",
-                    DisplayName = "Ngọc Huyền (Standard)", Region = "VN", Gender = "Female",
-                    Model = "ngochuyen", IsActive = true, CreatedAt = DateTime.UtcNow },
+                // Baseline & Existing models
                 new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "q4",
                     DisplayName = "VieNeu Fast (Q4)", Region = "VN", Gender = "Unknown",
                     Model = "q4", IsActive = true, CreatedAt = DateTime.UtcNow },
                 new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "q8",
                     DisplayName = "VieNeu High Quality (Q8)", Region = "VN", Gender = "Unknown",
                     Model = "q8", IsActive = true, CreatedAt = DateTime.UtcNow },
+                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "ngochuyen",
+                    DisplayName = "Ngọc Huyền (Standard)", Region = "VN", Gender = "Female",
+                    Model = "ngochuyen", IsActive = true, CreatedAt = DateTime.UtcNow },
+
+                // Additional voices from VieNeu-TTS reference
+                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "binh",
+                    DisplayName = "Bình (Male North)", Region = "North", Gender = "Male",
+                    Model = "binh", IsActive = true, CreatedAt = DateTime.UtcNow },
+                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "tuyen",
+                    DisplayName = "Tuyên (Male North)", Region = "North", Gender = "Male",
+                    Model = "tuyen", IsActive = true, CreatedAt = DateTime.UtcNow },
+                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "vinh",
+                    DisplayName = "Vinh (Male South)", Region = "South", Gender = "Male",
+                    Model = "vinh", IsActive = true, CreatedAt = DateTime.UtcNow },
+                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "ly",
+                    DisplayName = "Ly (Female North)", Region = "North", Gender = "Female",
+                    Model = "ly", IsActive = true, CreatedAt = DateTime.UtcNow },
+                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "ngoc",
+                    DisplayName = "Ngọc (Female North)", Region = "North", Gender = "Female",
+                    Model = "ngoc", IsActive = true, CreatedAt = DateTime.UtcNow },
+                new() { VoiceId = Guid.NewGuid(), Provider = "vieneutts", VoiceCode = "doan",
+                    DisplayName = "Đoan (Female South)", Region = "South", Gender = "Female",
+                    Model = "doan", IsActive = true, CreatedAt = DateTime.UtcNow },
             };
 
             var addedCount = 0;

--- a/services/ai-service/AiService.Application/Interfaces/IAudioConversionService.cs
+++ b/services/ai-service/AiService.Application/Interfaces/IAudioConversionService.cs
@@ -12,4 +12,9 @@ public interface IAudioConversionService
         string speechExtension,
         string bgmUrlOrPath,
         CancellationToken cancellationToken = default);
+
+    Task<(bool IsSuccess, byte[]? ConcatenatedBytes, string? ErrorMessage)> ConcatenateAudiosAsync(
+        List<byte[]> audioChunks,
+        string extension,
+        CancellationToken cancellationToken = default);
 }

--- a/services/ai-service/AiService.Application/Services/AudioService.cs
+++ b/services/ai-service/AiService.Application/Services/AudioService.cs
@@ -6,6 +6,7 @@ using AiService.Domain.Entities;
 using AiService.Domain.Enums;
 using AiService.Domain.Interfaces;
 using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace AiService.Application.Services;
 
@@ -74,28 +75,57 @@ public class AudioService : IAudioService
 
         try
         {
-            var ttsResp = await _tts.SynthesizeAsync(
-                new TtsSynthesizeRequest(
-                    Text: script.ContentText,
-                    VoiceCode: voice.VoiceCode,
-                    Model: voice.Model,
-                    Speed: request.Speed,
-                    Pitch: request.Pitch),
-                cancellationToken);
+            // --- TEXT CHUNKING LOGIC ---
+            var textChunks = SplitTextToChunks(script.ContentText, maxChunkLength: 300);
+            _logger.LogInformation("Split text into {Count} chunks for TTS generation", textChunks.Count);
 
-            var validationError = ValidateTtsResponse(script.ContentText, (double)(request.Speed ?? 1.0m), ttsResp);
-            if (validationError is not null)
+            var audioChunks = new List<byte[]>();
+            var totalDuration = 0;
+            string? firstContentType = null;
+
+            foreach (var chunk in textChunks)
             {
-                audio.Status = AudioStatus.Failed.ToString().ToLowerInvariant();
-                audio.UpdatedAt = DateTime.UtcNow;
-                await _audios.UpdateAsync(audio, cancellationToken);
-                await _uow.SaveChangesAsync(cancellationToken);
-                return Result<ScriptAudio>.Failure(validationError, (int)ApiStatusCode.HB50001);
+                if (string.IsNullOrWhiteSpace(chunk)) continue;
+
+                var ttsResp = await _tts.SynthesizeAsync(
+                    new TtsSynthesizeRequest(
+                        Text: chunk,
+                        VoiceCode: voice.VoiceCode,
+                        Model: voice.Model,
+                        Speed: request.Speed,
+                        Pitch: request.Pitch),
+                    cancellationToken);
+
+                var validationError = ValidateTtsResponse(chunk, (double)(request.Speed ?? 1.0m), ttsResp);
+                if (validationError is not null)
+                {
+                    _logger.LogError("TTS Chunk validation failed: {Error}", validationError);
+                    audio.Status = AudioStatus.Failed.ToString().ToLowerInvariant();
+                    audio.UpdatedAt = DateTime.UtcNow;
+                    await _audios.UpdateAsync(audio, cancellationToken);
+                    await _uow.SaveChangesAsync(cancellationToken);
+                    return Result<ScriptAudio>.Failure($"Chunk generation failed: {validationError}", (int)ApiStatusCode.HB50001);
+                }
+
+                audioChunks.Add(ttsResp.AudioBytes);
+                totalDuration += ttsResp.DurationSeconds ?? 0;
+                firstContentType ??= ttsResp.ContentType;
             }
 
-            var ext = ttsResp.ContentType.Contains("wav", StringComparison.OrdinalIgnoreCase) ? ".wav" : ".mp3";
-            var finalBytes = ttsResp.AudioBytes;
-            var contentType = ttsResp.ContentType;
+            if (audioChunks.Count == 0)
+                return Result<ScriptAudio>.Failure("No audio generated");
+
+            var ext = (firstContentType ?? "").Contains("wav", StringComparison.OrdinalIgnoreCase) ? ".wav" : ".mp3";
+            
+            // Concatenate all chunks
+            var concatResult = await _audioConversion.ConcatenateAudiosAsync(audioChunks, ext, cancellationToken);
+            if (!concatResult.IsSuccess || concatResult.ConcatenatedBytes == null)
+            {
+                return Result<ScriptAudio>.Failure($"Audio concatenation failed: {concatResult.ErrorMessage}", (int)ApiStatusCode.HB50001);
+            }
+
+            var finalBytes = concatResult.ConcatenatedBytes;
+            var contentType = firstContentType ?? "audio/mpeg";
 
             if (!string.IsNullOrWhiteSpace(request.BgmUrl))
             {
@@ -122,52 +152,68 @@ public class AudioService : IAudioService
 
             audio.AudioPath = stored.RelativePath;
             audio.AudioUrl = $"/api/audios/{audio.AudioId}/file";
-            audio.Duration = ttsResp.DurationSeconds;
+            audio.Duration = totalDuration;
             audio.Status = AudioStatus.Done.ToString().ToLowerInvariant();
             audio.UpdatedAt = DateTime.UtcNow;
 
             await _audios.UpdateAsync(audio, cancellationToken);
             await _uow.SaveChangesAsync(cancellationToken);
 
-            if (ttsResp.TokensUsed is not null || ttsResp.Cost is not null)
-            {
-                await _usage.LogAsync(new AiUsage
-                {
-                    UsageId = Guid.NewGuid(),
-                    UserId = request.UserId,
-                    Provider = "tts",
-                    TokensUsed = ttsResp.TokensUsed,
-                    Cost = ttsResp.Cost,
-                    ScriptId = script.ScriptId,
-                    CreatedAt = DateTime.UtcNow
-                }, cancellationToken);
-            }
-
             return Result<ScriptAudio>.Success(audio);
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Audio generation failed");
             audio.Status = AudioStatus.Failed.ToString().ToLowerInvariant();
             audio.UpdatedAt = DateTime.UtcNow;
 
             try
             {
-                // Use a non-cancelable token so we can best-effort persist failure status
-                // even if the original request token has already been canceled.
                 await _audios.UpdateAsync(audio, CancellationToken.None);
                 await _uow.SaveChangesAsync(CancellationToken.None);
             }
             catch (Exception persistEx)
             {
-                _logger.LogWarning(
-                    persistEx,
-                    "Failed to persist audio failure status for audioId {AudioId} after error: {OriginalError}",
-                    audio.AudioId,
-                    ex.Message);
+                _logger.LogWarning(persistEx, "Failed to persist audio failure status");
             }
 
             throw;
         }
+    }
+
+    private List<string> SplitTextToChunks(string text, int maxChunkLength)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return new List<string>();
+        if (text.Length <= maxChunkLength) return new List<string> { text };
+
+        var chunks = new List<string>();
+        var sentences = text.Split(new[] { ". ", "! ", "? ", ".\n", "!\n", "?\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        
+        var currentChunk = new StringBuilder();
+        foreach (var sentence in sentences)
+        {
+            var trimmed = sentence.Trim();
+            if (string.IsNullOrEmpty(trimmed)) continue;
+
+            // Re-add the punctuation if it's not the end of the text
+            var sentenceWithPunct = trimmed;
+            if (!char.IsPunctuation(trimmed.Last())) sentenceWithPunct += ".";
+
+            if (currentChunk.Length + sentenceWithPunct.Length > maxChunkLength && currentChunk.Length > 0)
+            {
+                chunks.Add(currentChunk.ToString().Trim());
+                currentChunk.Clear();
+            }
+            
+            currentChunk.Append(sentenceWithPunct).Append(" ");
+        }
+
+        if (currentChunk.Length > 0)
+        {
+            chunks.Add(currentChunk.ToString().Trim());
+        }
+
+        return chunks;
     }
 
     private static string? ValidateTtsResponse(string sourceText, double speed, TtsSynthesizeResponse response)
@@ -179,7 +225,7 @@ public class AudioService : IAudioService
             return $"TTS returned invalid content type '{response.ContentType}'.";
 
         var isWav = response.ContentType.Contains("wav", StringComparison.OrdinalIgnoreCase);
-        var minLength = isWav ? 45 : 256;
+        var minLength = isWav ? 44 : 128; // Reduced min size for chunks
         if (response.AudioBytes.Length < minLength)
             return $"TTS returned suspiciously small audio payload ({response.AudioBytes.Length} bytes).";
 
@@ -187,23 +233,6 @@ public class AudioService : IAudioService
         {
             if (!(response.AudioBytes[0] == 'R' && response.AudioBytes[1] == 'I' && response.AudioBytes[2] == 'F' && response.AudioBytes[3] == 'F'))
                 return "TTS WAV payload is missing RIFF header.";
-
-            if (!(response.AudioBytes[8] == 'W' && response.AudioBytes[9] == 'A' && response.AudioBytes[10] == 'V' && response.AudioBytes[11] == 'E'))
-                return "TTS WAV payload is missing WAVE header.";
-        }
-
-        // Duration must be present and positive
-        if (!response.DurationSeconds.HasValue || response.DurationSeconds.Value <= 0)
-            return $"TTS returned invalid duration ({(response.DurationSeconds.HasValue ? response.DurationSeconds.Value : 0)}s).";
-
-        var compactLength = CountNonWhitespaceChars(sourceText);
-        if (compactLength >= 20)
-        {
-            // Natural Vietnamese speech at ~18-22 chars/s. We use 35 chars/s as a loose bound to account for fast models and custom speeds.
-            var effectiveCharsPerSec = 35d * speed;
-            var minimumDuration = (int)Math.Floor(compactLength / effectiveCharsPerSec);
-            if (minimumDuration > 2 && response.DurationSeconds.Value < minimumDuration)
-                return $"TTS returned suspiciously short duration ({response.DurationSeconds.Value}s for {compactLength} chars).";
         }
 
         return null;

--- a/services/ai-service/AiService.Infrastructure/Services/AudioConversionService.cs
+++ b/services/ai-service/AiService.Infrastructure/Services/AudioConversionService.cs
@@ -153,6 +153,77 @@ public sealed class AudioConversionService : IAudioConversionService
         }
     }
 
+    public async Task<(bool IsSuccess, byte[]? ConcatenatedBytes, string? ErrorMessage)> ConcatenateAudiosAsync(
+        List<byte[]> audioChunks,
+        string extension,
+        CancellationToken cancellationToken = default)
+    {
+        if (audioChunks == null || audioChunks.Count == 0)
+            return (false, null, "No audio chunks to concatenate");
+
+        if (audioChunks.Count == 1)
+            return (true, audioChunks[0], null);
+
+        var tempFiles = new List<string>();
+        var listFile = Path.Combine(Path.GetTempPath(), $"concat_list_{Guid.NewGuid():N}.txt");
+        var tempOut = Path.Combine(Path.GetTempPath(), $"concat_out_{Guid.NewGuid():N}{extension}");
+
+        try
+        {
+            var listContent = new StringBuilder();
+            foreach (var chunk in audioChunks)
+            {
+                var chunkFile = Path.Combine(Path.GetTempPath(), $"chunk_{Guid.NewGuid():N}{extension}");
+                await File.WriteAllBytesAsync(chunkFile, chunk, cancellationToken);
+                tempFiles.Add(chunkFile);
+                
+                // Escape single quotes for FFmpeg concat file format
+                var escapedPath = chunkFile.Replace("'", "'\\''");
+                listContent.AppendLine($"file '{escapedPath}'");
+            }
+
+            await File.WriteAllTextAsync(listFile, listContent.ToString(), cancellationToken);
+
+            // -f concat -safe 0: use the list file to concatenate
+            // -c copy: don't re-encode if possible (fast and lossless for same formats)
+            var args = $"-y -f concat -safe 0 -i \"{listFile}\" -c copy \"{tempOut}\"";
+            
+            var ffmpegResult = await RunFFmpegProcessAsync(args, cancellationToken);
+            if (ffmpegResult.Success && File.Exists(tempOut))
+            {
+                var concatenatedBytes = await File.ReadAllBytesAsync(tempOut, cancellationToken);
+                return (true, concatenatedBytes, null);
+            }
+
+            // Fallback: If 'copy' fails (e.g. different sample rates), try re-encoding
+            _logger.LogWarning("FFmpeg concat-copy failed, retrying with re-encoding: {Error}", ffmpegResult.ErrorMessage);
+            var reencodeArgs = $"-y -f concat -safe 0 -i \"{listFile}\" \"{tempOut}\"";
+            var reencodeResult = await RunFFmpegProcessAsync(reencodeArgs, cancellationToken);
+            
+            if (reencodeResult.Success && File.Exists(tempOut))
+            {
+                var concatenatedBytes = await File.ReadAllBytesAsync(tempOut, cancellationToken);
+                return (true, concatenatedBytes, null);
+            }
+
+            return (false, null, reencodeResult.ErrorMessage ?? "FFmpeg concatenation failed");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Audio concatenation failed");
+            return (false, null, ex.Message);
+        }
+        finally
+        {
+            try { if (File.Exists(listFile)) File.Delete(listFile); } catch { }
+            try { if (File.Exists(tempOut)) File.Delete(tempOut); } catch { }
+            foreach (var file in tempFiles)
+            {
+                try { if (File.Exists(file)) File.Delete(file); } catch { }
+            }
+        }
+    }
+
     private async Task<(bool Success, string? ErrorMessage)> RunFFmpegProcessAsync(string args, CancellationToken cancellationToken)
     {
         var startInfo = new ProcessStartInfo

--- a/services/live-session-service/LiveSessionService.Api/Controllers/PodcastEpisodeRequestController.cs
+++ b/services/live-session-service/LiveSessionService.Api/Controllers/PodcastEpisodeRequestController.cs
@@ -8,6 +8,8 @@ using LiveSessionService.Application.Features.PodcastEpisodeRequests.Commands.Re
 using LiveSessionService.Application.Features.PodcastEpisodeRequests.Queries.GetPodcastEpisodeRequests;
 using LiveSessionService.Application.Features.PodcastEpisodeRequests.Queries.GetMyPodcastEpisodeRequests;
 using LiveSessionService.Application.Features.PodcastEpisodeRequests.Queries.GetPodcastEpisodeRequestById;
+using LiveSessionService.Application.Features.PodcastEpisodeRequests.Commands.CheckPodcastEpisodeToxicity;
+using LiveSessionService.Domain.Interfaces;
 using LiveSessionService.Api.Models.Responses;
 using LiveSessionService.Api.Extensions;
 using Microsoft.AspNetCore.Authorization;
@@ -191,5 +193,26 @@ public class PodcastEpisodeRequestController : ControllerBase
         }
 
         return Ok(result.ToApiResponse());
+    }
+
+    [HttpPost("{id:guid}/check-toxicity")]
+    [Authorize(Roles = "STAFF,ADMIN")]
+    [ProducesResponseType(typeof(ApiResponse<ModerationResult>), 200)]
+    public async Task<IActionResult> CheckToxicity(Guid id, CancellationToken ct)
+    {
+        var command = new CheckPodcastEpisodeToxicityCommand(id);
+        var result = await _commands.Send<CheckPodcastEpisodeToxicityCommand, ModerationResult>(command, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                ErrorCode.NotFound => NotFound(result.ToApiResponse()),
+                ErrorCode.BadRequest => BadRequest(result.ToApiResponse()),
+                _ => StatusCode((int)(result.ErrorCode ?? ErrorCode.InternalServerError), result.ToApiResponse())
+            };
+        }
+
+        return Ok(ApiResponse<ModerationResult>.SuccessResponse(result.Data!, "Toxicity check completed successfully"));
     }
 }

--- a/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Application/DependencyInjection.cs
@@ -51,6 +51,8 @@ using LiveSessionService.Application.Features.PodcastEpisodeRequests.Commands.Re
 using LiveSessionService.Application.Features.PodcastEpisodeRequests.Queries.GetPodcastEpisodeRequests;
 using LiveSessionService.Application.Features.PodcastEpisodeRequests.Queries.GetMyPodcastEpisodeRequests;
 using LiveSessionService.Application.Features.PodcastEpisodeRequests.Queries.GetPodcastEpisodeRequestById;
+using LiveSessionService.Application.Features.PodcastEpisodeRequests.Commands.CheckPodcastEpisodeToxicity;
+using LiveSessionService.Domain.Interfaces;
 using LiveSessionService.Application.Features.Results.PodcastRequests;
 using LiveSessionService.Application.Features.Playlists.Commands.AddMediaToPlaylist;
 using LiveSessionService.Application.Features.Playlists.Commands.AddTracksToUserPlaylist;
@@ -243,6 +245,7 @@ public static class DependencyInjection
         // Register PodcastEpisodeRequest Command Handlers
         services.AddScoped<ICommandHandler<CreatePodcastEpisodeRequestCommand, PodcastEpisodeRequestResult>, CreatePodcastEpisodeRequestHandler>();
         services.AddScoped<ICommandHandler<ReviewPodcastEpisodeRequestCommand, PodcastEpisodeRequestResult>, ReviewPodcastEpisodeRequestHandler>();
+        services.AddScoped<ICommandHandler<CheckPodcastEpisodeToxicityCommand, ModerationResult>, CheckPodcastEpisodeToxicityHandler>();
 
         // Register PodcastEpisodeRequest Query Handlers
         services.AddScoped<IQueryHandler<GetPodcastEpisodeRequestsQuery, List<PodcastEpisodeRequestResult>>, GetPodcastEpisodeRequestsHandler>();

--- a/services/live-session-service/LiveSessionService.Application/Features/PodcastEpisodeRequests/Commands/CheckPodcastEpisodeToxicity/CheckPodcastEpisodeToxicityCommand.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/PodcastEpisodeRequests/Commands/CheckPodcastEpisodeToxicity/CheckPodcastEpisodeToxicityCommand.cs
@@ -1,0 +1,6 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Domain.Interfaces;
+
+namespace LiveSessionService.Application.Features.PodcastEpisodeRequests.Commands.CheckPodcastEpisodeToxicity;
+
+public record CheckPodcastEpisodeToxicityCommand(Guid RequestId) : ICommand<ModerationResult>;

--- a/services/live-session-service/LiveSessionService.Application/Features/PodcastEpisodeRequests/Commands/CheckPodcastEpisodeToxicity/CheckPodcastEpisodeToxicityHandler.cs
+++ b/services/live-session-service/LiveSessionService.Application/Features/PodcastEpisodeRequests/Commands/CheckPodcastEpisodeToxicity/CheckPodcastEpisodeToxicityHandler.cs
@@ -1,0 +1,36 @@
+using LiveSessionService.Application.Abstractions.Messaging;
+using LiveSessionService.Application.Enums;
+using LiveSessionService.Application.Features.Results;
+using LiveSessionService.Domain.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LiveSessionService.Application.Features.PodcastEpisodeRequests.Commands.CheckPodcastEpisodeToxicity;
+
+public sealed class CheckPodcastEpisodeToxicityHandler : ICommandHandler<CheckPodcastEpisodeToxicityCommand, ModerationResult>
+{
+    private readonly IPodcastEpisodeRequestRepository _repository;
+    private readonly IAudioModerationService _moderationService;
+
+    public CheckPodcastEpisodeToxicityHandler(
+        IPodcastEpisodeRequestRepository repository,
+        IAudioModerationService moderationService)
+    {
+        _repository = repository;
+        _moderationService = moderationService;
+    }
+
+    public async Task<Result<ModerationResult>> Handle(CheckPodcastEpisodeToxicityCommand command, CancellationToken cancellationToken)
+    {
+        var request = await _repository.GetByIdAsync(command.RequestId, cancellationToken);
+        if (request == null)
+            return Result<ModerationResult>.Failure("Episode request not found", ErrorCode.NotFound);
+
+        if (string.IsNullOrWhiteSpace(request.AudioUrl))
+            return Result<ModerationResult>.Failure("Episode request has no audio URL", ErrorCode.BadRequest);
+
+        var moderationResult = await _moderationService.CheckToxicityAsync(request.AudioUrl, cancellationToken);
+
+        return Result<ModerationResult>.Success(moderationResult);
+    }
+}

--- a/services/live-session-service/LiveSessionService.Domain/Interfaces/IAudioModerationService.cs
+++ b/services/live-session-service/LiveSessionService.Domain/Interfaces/IAudioModerationService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LiveSessionService.Domain.Interfaces
+{
+    public interface IAudioModerationService
+    {
+        Task<ModerationResult> CheckToxicityAsync(string audioUrl, CancellationToken cancellationToken = default);
+    }
+
+    public class ModerationResult
+    {
+        public double ToxicityScore { get; set; }
+        public double InsultScore { get; set; }
+        public double ProfanityScore { get; set; }
+        public string Action { get; set; } = string.Empty;
+        public string[] TriggeredWords { get; set; } = System.Array.Empty<string>();
+        public string Transcript { get; set; } = string.Empty;
+    }
+}

--- a/services/live-session-service/LiveSessionService.Infrastructure/DependencyInjection.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/DependencyInjection.cs
@@ -111,6 +111,9 @@ public static class DependencyInjection
         services.AddHttpClient("CloudinaryDownload");
         services.AddSingleton<ICloudinaryMediaStorage, CloudinaryMediaStorage>();
 
+        // Audio Moderation
+        services.AddScoped<IAudioModerationService, AudioModerationService>();
+
         // External Services - AzuraCast
         // Read from environment variables (Docker) or config
         var azuraCastBaseUrl = Environment.GetEnvironmentVariable("AZURACAST_BASE_URL")

--- a/services/live-session-service/LiveSessionService.Infrastructure/LiveSessionService.Infrastructure.csproj
+++ b/services/live-session-service/LiveSessionService.Infrastructure/LiveSessionService.Infrastructure.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CloudinaryDotNet" Version="1.28.0" />
+		<PackageReference Include="Google.Cloud.Speech.V1" Version="3.9.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">

--- a/services/live-session-service/LiveSessionService.Infrastructure/Services/AudioModerationService.cs
+++ b/services/live-session-service/LiveSessionService.Infrastructure/Services/AudioModerationService.cs
@@ -1,0 +1,164 @@
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Speech.V1;
+using Grpc.Auth;
+using LiveSessionService.Domain.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiveSessionService.Infrastructure.Services
+{
+    public class AudioModerationService : IAudioModerationService
+    {
+        private readonly ILogger<AudioModerationService> _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly string _credentialsJson;
+
+        private static readonly string[] SevereWords = new[]
+        {
+            "giết", "ám sát", "đồ sát", "bắn chết", "đâm chém", "cắt cổ", "khủng bố", "chặt chém", "buôn ma túy",
+            "tự sát", "tự tử", "chết đi", "nhảy lầu", "thắt cổ", "uống thuốc chuột",
+            "hiếp dâm", "ấu dâm", "loạn luân", "cưỡng hiếp", 
+            "nứng", "dâm", "quay tay", "làm tình", "thẩm du",
+            "đĩ", "phò", "cave", "gái gọi", "đi khách",
+            "địt", "đụ", "lồn", "cặc", "buồi", "dái", "đm", "đcm", "vcl", "vkl", "vl", "đmày", "đệt", "mẹ kiếp"
+        };
+
+        private static readonly string[] BadWords = new[]
+        {
+            "ngu", "óc chó", "khốn nạn", "chó", "điên", "súc vật", "rác rưởi", "cặn bã", "đồ lợn", "mất dạy"
+        };
+
+        // Precompiled regex for optimization
+        private static readonly Regex SevereRegex = new Regex($@"(?<!\S)({string.Join("|", SevereWords.Select(Regex.Escape))})(?!\S)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex BadRegex = new Regex($@"(?<!\S)({string.Join("|", BadWords.Select(Regex.Escape))})(?!\S)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public AudioModerationService(ILogger<AudioModerationService> logger, IHttpClientFactory httpClientFactory, IConfiguration configuration)
+        {
+            _logger = logger;
+            _httpClientFactory = httpClientFactory;
+            
+            // Read from GOOGLE_CREDENTIALS_BASE64 environment variable or config
+            var credentialsBase64 = Environment.GetEnvironmentVariable("GOOGLE_CREDENTIALS_BASE64") 
+                ?? configuration["GoogleCloud:CredentialsBase64"];
+
+            if (!string.IsNullOrWhiteSpace(credentialsBase64))
+            {
+                try
+                {
+                    var bytes = Convert.FromBase64String(credentialsBase64);
+                    _credentialsJson = System.Text.Encoding.UTF8.GetString(bytes);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to decode GOOGLE_CREDENTIALS_BASE64");
+                    _credentialsJson = string.Empty;
+                }
+            }
+            else
+            {
+                // Fallback to plain JSON string if set
+                _credentialsJson = Environment.GetEnvironmentVariable("GOOGLE_CREDENTIALS_JSON") 
+                    ?? configuration["GoogleCloud:CredentialsJson"] 
+                    ?? string.Empty;
+            }
+
+            if (string.IsNullOrWhiteSpace(_credentialsJson))
+            {
+                _logger.LogWarning("GOOGLE_CREDENTIALS_JSON is not configured. Google Speech-to-Text may fail.");
+            }
+        }
+
+        public async Task<ModerationResult> CheckToxicityAsync(string audioUrl, CancellationToken cancellationToken = default)
+        {
+            var result = new ModerationResult();
+
+            try
+            {
+                var client = _httpClientFactory.CreateClient();
+                var audioBytes = await client.GetByteArrayAsync(audioUrl, cancellationToken);
+                
+                var speechClient = await new SpeechClientBuilder
+                {
+                    GoogleCredential = GoogleCredential.FromJson(_credentialsJson)
+                }.BuildAsync(cancellationToken);
+
+                var response = await speechClient.RecognizeAsync(new RecognizeRequest
+                {
+                    Config = new RecognitionConfig
+                    {
+                        LanguageCode = "vi-VN"
+                    },
+                    Audio = RecognitionAudio.FromBytes(audioBytes)
+                });
+                
+                var transcripts = response.Results.Select(r => r.Alternatives.FirstOrDefault()?.Transcript).Where(t => t != null);
+                var final_text = string.Join("\n", transcripts).Trim();
+                if (string.IsNullOrEmpty(final_text))
+                {
+                    final_text = "[No speech detected]";
+                }
+                
+                result.Transcript = final_text;
+                return AnalyzeToxicity(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "STT Error");
+                return new ModerationResult
+                {
+                    Action = "SAFE",
+                    Transcript = "[Lỗi STT: " + ex.Message + "]",
+                };
+            }
+        }
+        
+        private ModerationResult AnalyzeToxicity(ModerationResult result)
+        {
+            var text = result.Transcript.ToLowerInvariant();
+            if (string.IsNullOrWhiteSpace(text) || text == "[no speech detected]")
+            {
+                result.Action = "SAFE";
+                return result;
+            }
+
+            var severeMatches = SevereRegex.Matches(text);
+            int severeCount = severeMatches.Count;
+            var severeFound = severeMatches.Select(m => m.Value).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+            var badMatches = BadRegex.Matches(text);
+            int badCount = badMatches.Count;
+            var badFound = badMatches.Select(m => m.Value).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+            result.ToxicityScore = Math.Min(1.0, badCount * 0.3 + severeCount * 0.5);
+            result.InsultScore = Math.Min(1.0, badCount * 0.4);
+            result.ProfanityScore = Math.Min(1.0, badCount * 0.5);
+
+            if (severeCount > 0)
+            {
+                result.Action = "REJECT";
+            }
+            else if (badCount > 0)
+            {
+                result.Action = "PENDING_REVIEW";
+            }
+            else
+            {
+                result.Action = "SAFE";
+            }
+
+            var triggered = new List<string>();
+            triggered.AddRange(severeFound);
+            triggered.AddRange(badFound);
+            result.TriggeredWords = triggered.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Split long TTS texts into chunks and concatenate audio outputs; add audio moderation pipeline.

- AiService: implement text chunking for TTS generation, accumulate durations, validate per-chunk, and concatenate chunks via new IAudioConversionService.ConcatenateAudiosAsync. Lowered chunk size validation threshold and added multiple default VieNeu TTS voices in migrations.
- AudioConversionService: add concat implementation using FFmpeg (concat list + fallback re-encode), with temp file handling and error reporting.
- LiveSessionService: introduce IAudioModerationService and AudioModerationService (Google Speech-to-Text based), register service and package reference, and add CheckPodcastEpisodeToxicity command/handler + controller endpoint to run moderation on episode audio. Uses GOOGLE_CREDENTIALS_BASE64 env var (added to docker-compose) for Google credentials.

Purpose: support reliable TTS for long scripts by chunking and merging outputs, and enable automated toxicity checks on podcast audio using STT + simple rule-based analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added moderation endpoint to check podcast episode audio for toxicity (staff/admin protected feature)
  * Enhanced text-to-speech with chunked synthesis for improved handling of extended content
  * Expanded Vietnamese voice options for text-to-speech functionality
  * Improved audio processing with multi-chunk concatenation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->